### PR TITLE
single page app nginx config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ COPY --chown=root:root --from=builder /srv/dist /usr/share/nginx/html
 
 COPY --from=builder /srv/env.var.list /srv/env.var.list
 COPY --chown=root:root replace-env-var-placeholders.sh /usr/local/bin/replace-env-var-placeholders.sh
+COPY --chown=root:root nginx.conf /etc/nginx/conf.d/default.conf
 
 ################################################################
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,17 @@
+server {
+    listen 0.0.0.0:80;
+
+    server_name  _;
+
+    root /usr/share/nginx/html;
+
+    index index.html;
+
+    location /assets/ {
+        try_files $uri =404;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
implements single page app nginx config; all js/css/image assets are served if found under `/usr/share/nginx/html/assets/`, but 404 if missing - all other invalid urls are served via `/index.html` instead of receiving 404