### PR TITLE
Style / Formatting changes

### DIFF
--- a/src/components/DidSelect/index.tsx
+++ b/src/components/DidSelect/index.tsx
@@ -12,7 +12,6 @@ import {
 } from './styles';
 import { formatDid } from '~/helpers/formatters';
 import { notifyError } from '~/helpers/notifications';
-import { useWindowWidth } from '~/hooks/utility';
 import { SkeletonLoader } from '../UiKit';
 
 const DidSelect = () => {
@@ -21,10 +20,12 @@ const DidSelect = () => {
   const [expanded, setExpanded] = useState(false);
   const [selected, setSelected] = useState<Identity | null>(null);
   const ref = useRef<HTMLDivElement>(null);
-  const { windowWidth } = useWindowWidth();
 
   useEffect(() => {
-    if (!identity) return;
+    if (!identity) {
+      setSelected(null);
+      return;
+    }
 
     setSelected(identity);
   }, [identity]);
@@ -81,13 +82,13 @@ const DidSelect = () => {
   const handleDropdownToggle = () => {
     setExpanded((prev) => !prev);
   };
-
-  const truncateLength = Math.ceil(windowWidth / 77);
+  const wrapperWidth = ref.current?.clientWidth ?? 0;
+  const truncateLength = Math.floor((wrapperWidth - 30) / 18);
 
   return selected ? (
     <StyledSelectWrapper ref={ref}>
       <StyledSelect onClick={handleDropdownToggle} expanded={expanded}>
-        {formatDid(selected.did, truncateLength, truncateLength - 1)}
+        {formatDid(selected.did, truncateLength, truncateLength - 2)}
         <IconWrapper>
           <Icon name="DropdownIcon" />
         </IconWrapper>
@@ -101,7 +102,7 @@ const DidSelect = () => {
               htmlFor={option?.did}
               selected={selected?.did === option?.did}
             >
-              {formatDid(option?.did, truncateLength, truncateLength)}
+              {formatDid(option?.did, truncateLength - 2, truncateLength - 2)}
               <StyledInput
                 type="radio"
                 name="key"

--- a/src/components/Header/components/BalanceInfo/styles.ts
+++ b/src/components/Header/components/BalanceInfo/styles.ts
@@ -6,6 +6,8 @@ export const StyledWrapper = styled.div`
   justify-content: space-between;
   gap: 8px;
   min-width: 118px;
+  padding-left: 8px;
+  white-space: nowrap;
 `;
 
 export const StyledPriceLabel = styled.span`

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -53,8 +53,6 @@ const Header: React.FC<IHeaderProps> = ({ toggleMobileMenu }) => {
           )}
           <StyledInfoItem>
             <KeysInfo />
-          </StyledInfoItem>
-          <StyledInfoItem>
             <NotificationInfo />
           </StyledInfoItem>
         </StyledInfoList>

--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -33,13 +33,13 @@ export const StyledHeaderContainer = styled.div`
 export const StyledInfoList = styled.ul`
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
 
   @media screen and (max-width: 767px) {
     margin-left: auto;
   }
 
   @media screen and (max-width: 1023px) {
-    max-width: 300px;
     flex-wrap: wrap;
     justify-content: flex-end;
   }
@@ -49,11 +49,14 @@ export const StyledInfoItem = styled.li`
   display: flex;
   align-items: center;
   gap: 16px;
+
   @media screen and (min-width: 768px) and (max-width: 1023px) {
     gap: 8px;
   }
+
   &:not(:first-child) {
     margin-left: 16px;
+
     @media screen and (min-width: 768px) and (max-width: 1023px) {
       margin-left: 8px;
     }
@@ -68,12 +71,6 @@ export const StyledInfoItem = styled.li`
 
   &:last-child {
     margin-left: 4px;
-  }
-
-  @media screen and (max-width: 1024px) {
-    &:nth-child(2)::after {
-      display: none;
-    }
   }
 `;
 

--- a/src/components/UiKit/Text/index.tsx
+++ b/src/components/UiKit/Text/index.tsx
@@ -10,6 +10,7 @@ const Text: React.FC<ITextProps> = ({
   size = ETextSize.MEDIUM,
   bold,
   transform,
+  truncateOverflow,
   children,
 }) => {
   return (
@@ -22,6 +23,7 @@ const Text: React.FC<ITextProps> = ({
       size={size}
       bold={bold}
       transform={transform}
+      truncateOverflow={truncateOverflow}
     >
       {children}
     </StyledText>

--- a/src/components/UiKit/Text/styles.ts
+++ b/src/components/UiKit/Text/styles.ts
@@ -10,6 +10,7 @@ export const StyledText = styled.p<{
   size?: `${ETextSize}`;
   bold?: boolean;
   transform?: `${ETextTransform}`;
+  truncateOverflow?: boolean; // Renamed prop to truncate
 }>`
   ${({
     theme,
@@ -21,8 +22,9 @@ export const StyledText = styled.p<{
     size = ETextSize.MEDIUM,
     bold,
     transform,
+    truncateOverflow,
   }) => `
-        ${width ? `width: ${width}px` : ''};
+        ${width ? `width: ${width}px;` : ''}
         ${centered ? 'text-align: center;' : ''}
         ${marginTop ? `margin-top: ${marginTop}px;` : ''}
         ${marginBottom ? `margin-bottom: ${marginBottom}px;` : ''}
@@ -39,5 +41,14 @@ export const StyledText = styled.p<{
         font-weight: ${bold ? '500' : '400'};
         font-size: ${theme.textSize[size]};
         text-transform: ${transform || 'none'};
+        ${
+          truncateOverflow
+            ? `
+              white-space: nowrap;
+              overflow: hidden;
+              text-overflow: ellipsis;
+            `
+            : ''
+        }
     `}
 `;

--- a/src/components/UiKit/Text/types.ts
+++ b/src/components/UiKit/Text/types.ts
@@ -24,5 +24,6 @@ export interface ITextProps {
   size?: `${ETextSize}`;
   bold?: boolean;
   transform?: `${ETextTransform}`;
+  truncateOverflow?: boolean;
   children: React.ReactNode;
 }

--- a/src/components/WalletSelect/index.tsx
+++ b/src/components/WalletSelect/index.tsx
@@ -12,13 +12,9 @@ import {
 } from './styles';
 import { formatKey } from '~/helpers/formatters';
 import { ESelectPlacements, ISelectProps } from './types';
-import { useWindowWidth } from '~/hooks/utility';
 import { SkeletonLoader } from '../UiKit';
 
-const WalletSelect: React.FC<ISelectProps> = ({
-  placement = 'header',
-  trimValue = true,
-}) => {
+const WalletSelect: React.FC<ISelectProps> = ({ placement = 'header' }) => {
   const {
     selectedAccount,
     setSelectedAccount,
@@ -27,18 +23,20 @@ const WalletSelect: React.FC<ISelectProps> = ({
     secondaryKeys,
   } = useContext(AccountContext);
   const [expanded, setExpanded] = useState(false);
-  const [selected, setSelected] = useState('');
   const ref = useRef<HTMLDivElement>(null);
-  const { isMobile } = useWindowWidth();
+  const [selectedKeyName, setSelectedKeyName] = useState('');
 
   useEffect(() => {
     if (!selectedAccount) {
-      setSelected('');
+      setSelectedKeyName('');
       return;
     }
 
-    setSelected(selectedAccount);
-  }, [selectedAccount]);
+    const keyName = allAccountsWithMeta.find(
+      ({ address }) => address === selectedAccount,
+    )?.meta.name;
+    setSelectedKeyName(keyName || '');
+  }, [selectedAccount, allAccountsWithMeta]);
 
   // Close dropdown when clicked outside of it
   useEffect(() => {
@@ -56,7 +54,6 @@ const WalletSelect: React.FC<ISelectProps> = ({
 
   const handleAccountChange: React.ReactEventHandler = ({ target }) => {
     setSelectedAccount((target as HTMLInputElement).value);
-    setSelected((target as HTMLInputElement).value);
     setExpanded(false);
   };
 
@@ -64,16 +61,19 @@ const WalletSelect: React.FC<ISelectProps> = ({
     setExpanded((prev) => !prev);
   };
 
-  return selected ? (
+  const wrapperWidth = ref.current?.clientWidth ?? 150;
+  const truncateLength = Math.floor((wrapperWidth - 30) / 18);
+
+  return selectedAccount ? (
     <StyledSelectWrapper ref={ref} placement={placement}>
       <StyledSelect
         onClick={handleDropdownToggle}
         expanded={expanded}
         placement={placement}
       >
-        {trimValue
-          ? formatKey(selected)
-          : formatKey(selected, isMobile ? 6 : 8, isMobile ? 6 : 8)}
+        {placement === 'widget'
+          ? formatKey(selectedAccount, truncateLength, truncateLength)
+          : selectedKeyName}
         <IconWrapper>
           <Icon name="DropdownIcon" />
         </IconWrapper>
@@ -97,14 +97,12 @@ const WalletSelect: React.FC<ISelectProps> = ({
               <StyledLabel
                 key={address}
                 htmlFor={address}
-                selected={selected === address}
+                selected={selectedAccount === address}
                 placement={placement}
               >
                 <span>
-                  {trimValue
-                    ? formatKey(address)
-                    : formatKey(address, isMobile ? 6 : 8, isMobile ? 6 : 8)}
                   <span className="meta">{meta.name || ''}</span>
+                  <span className="key">{formatKey(address, 8, 7)}</span>
                 </span>
                 {address === primaryKey ? (
                   <StyledKeyLabel primary>Primary</StyledKeyLabel>

--- a/src/components/WalletSelect/styles.ts
+++ b/src/components/WalletSelect/styles.ts
@@ -10,7 +10,8 @@ export const StyledSelectWrapper = styled.div<{
     placement === ESelectPlacements.HEADER
       ? `
       padding-right: 16px;
-      min-width: 94px;
+      max-width: 150px;
+
       `
       : ''}
   ${({ placement }) =>
@@ -30,6 +31,9 @@ export const StyledSelect = styled.div<{
 }>`
   font-weight: 500;
   font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 
   ${({ placement, theme }) =>
     placement === ESelectPlacements.HEADER
@@ -82,24 +86,17 @@ export const StyledExpandedSelect = styled.div<{
     placement === ESelectPlacements.HEADER
       ? `
       top: 120%;
-      left: -56%;
-      width: 203px;
-      
+      right: -25px;
+      width: 250px;
       `
       : ''}
   ${({ placement }) =>
     placement === ESelectPlacements.WIDGET
       ? `
       top: 110%;
-      left: 0;
-      width: 100%;
-      @media screen and (max-width: 400px) {
-        left: -40%;
-        min-width: 260px;
-      }
-      @media screen and (max-width: 767px) {
-        width: 120%;
-      }
+      right: -40px;
+      width: calc(100% + 40px);
+      min-width: 280px;
       text-align: center;
       `
       : ''}
@@ -112,7 +109,6 @@ export const StyledInput = styled.input`
   margin: -1px;
   border: 0;
   padding: 0;
-
   white-space: nowrap;
   clip-path: inset(100%);
   clip: rect(0 0 0 0);
@@ -149,8 +145,16 @@ export const StyledLabel = styled.label<{
     align-items: flex-start;
     font-size: ${({ placement }) =>
       placement === ESelectPlacements.HEADER ? '12px' : '14px'};
+    max-width: calc(100% - 63px);
 
     & .meta {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 100%;
+    }
+
+    & .key {
       color: ${({ theme }) => theme.colors.textSecondary};
     }
   }

--- a/src/components/WalletSelect/types.ts
+++ b/src/components/WalletSelect/types.ts
@@ -5,5 +5,4 @@ export enum ESelectPlacements {
 
 export interface ISelectProps {
   placement?: `${ESelectPlacements}`;
-  trimValue?: boolean;
 }

--- a/src/helpers/formatters.ts
+++ b/src/helpers/formatters.ts
@@ -11,9 +11,11 @@ export const formatDid = (
 export const formatKey = (key: string, startChars = 4, endChars = 5) => {
   return `${key.slice(0, startChars)}...${key.slice(key.length - endChars)}`;
 };
-
-export const formatBalance = (balance: string | number, decimals = 2) =>
-  Number(balance).toFixed(decimals);
+export const formatBalance = (balance: string | number, decimals = 6) => {
+  return Number(balance).toLocaleString(undefined, {
+    maximumFractionDigits: decimals,
+  });
+};
 
 export const stringToColor = (str: string) => {
   let hash = 0;
@@ -25,7 +27,7 @@ export const stringToColor = (str: string) => {
   for (let i = 0; i < 3; i += 1) {
     // eslint-disable-next-line no-bitwise
     const value = (hash >> (i * 3)) & 0xff;
-    color += `00${value.toString(16)}`.substr(-2);
+    color += `00${value.toString(16)}`.slice(-2);
   }
   return color;
 };

--- a/src/helpers/formatters.ts
+++ b/src/helpers/formatters.ts
@@ -1,16 +1,27 @@
 export const formatDid = (
   did: string | undefined | null,
-  startChars = 4,
-  endChars = 5,
+  startChars = 6,
+  endChars = 4,
 ) => {
   if (!did) return '';
-
-  return `${did.slice(0, startChars)}...${did.slice(did.length - endChars)}`;
+  // Ensure startChars and endChars are greater than mins
+  const formattedStartChars = Math.max(5, startChars);
+  const formattedEndChars = Math.max(3, endChars);
+  if (startChars + endChars >= did.length) return did;
+  return `${did.slice(0, formattedStartChars)}...${did.slice(
+    did.length - formattedEndChars,
+  )}`;
 };
 
-export const formatKey = (key: string, startChars = 4, endChars = 5) => {
-  return `${key.slice(0, startChars)}...${key.slice(key.length - endChars)}`;
+export const formatKey = (key: string, startChars = 5, endChars = 5) => {
+  const formattedStartChars = Math.max(3, startChars);
+  const formattedEndChars = Math.max(3, endChars);
+  if (startChars + endChars >= key.length) return key;
+  return `${key.slice(0, formattedStartChars)}...${key.slice(
+    key.length - formattedEndChars,
+  )}`;
 };
+
 export const formatBalance = (balance: string | number, decimals = 6) => {
   return Number(balance).toLocaleString(undefined, {
     maximumFractionDigits: decimals,

--- a/src/helpers/formatters.ts
+++ b/src/helpers/formatters.ts
@@ -51,3 +51,14 @@ export const splitByCapitalLetters = (text: string) => {
       .join(' ') || text
   );
 };
+
+export const truncateText = (
+  text: string | undefined | null,
+  maxLength: number,
+): string => {
+  if (!text) return '';
+  if (text.length <= maxLength) {
+    return text;
+  }
+  return `${text.slice(0, maxLength)}...`;
+};

--- a/src/layouts/Overview/components/BalanceInfo/components/ReceivePolyx/index.tsx
+++ b/src/layouts/Overview/components/BalanceInfo/components/ReceivePolyx/index.tsx
@@ -35,7 +35,7 @@ export const ReceivePolyx: React.FC<IReceivePolyxProps> = ({ toggleModal }) => {
         <TextWithDelimeter>Or</TextWithDelimeter>
         <Text color="secondary">Copy your key</Text>
         <StyledAddressWrapper>
-          {formatKey(selectedAccount, 11, 12)}
+          {formatKey(selectedAccount, isMobile ? 15 : 24, isMobile ? 15 : 24)}
           <CopyToClipboard value={selectedAccount} />
         </StyledAddressWrapper>
       </StyledWrapper>

--- a/src/layouts/Overview/components/DidInfo/components/Details/index.tsx
+++ b/src/layouts/Overview/components/DidInfo/components/Details/index.tsx
@@ -171,7 +171,11 @@ export const Details: React.FC<IDetailsProps> = ({
                 <StyledKeyData key={key}>
                   <KeyInfo>
                     <div className="name-container">
-                      {keyName && <Text bold>{keyName}</Text>}
+                      {keyName && (
+                        <Text bold truncateOverflow>
+                          {keyName}
+                        </Text>
+                      )}
                     </div>
                     <div className="status-container">
                       {available && (

--- a/src/layouts/Overview/components/DidInfo/components/Details/styles.ts
+++ b/src/layouts/Overview/components/DidInfo/components/Details/styles.ts
@@ -120,7 +120,11 @@ export const KeyInfo = styled.div`
   align-items: center;
   justify-content: space-between;
 
-  .name-container,
+  .name-container {
+    min-width: 100px;
+    padding-right: 8px;
+  }
+
   .status-container {
     display: flex;
     align-items: center;

--- a/src/layouts/Overview/components/KeyInfo/index.tsx
+++ b/src/layouts/Overview/components/KeyInfo/index.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useEffect, useState, useContext, useRef } from 'react';
 import { AccountContext } from '~/context/AccountContext';
 import { Icon, CopyToClipboard, WalletSelect } from '~/components';
 import { SkeletonLoader, Text } from '~/components/UiKit';
@@ -9,6 +9,7 @@ import {
   StyledLabel,
 } from './styles';
 import { useWindowWidth } from '~/hooks/utility';
+import { truncateText } from '~/helpers/formatters';
 
 export const KeyInfo = () => {
   const {
@@ -20,10 +21,26 @@ export const KeyInfo = () => {
     identityLoading,
   } = useContext(AccountContext);
   const { isMobile, isSmallDesktop } = useWindowWidth();
+  const ref = useRef<HTMLDivElement>(null);
+  const [selectedKeyName, setSelectedKeyName] = useState('');
 
-  const selectedKeyName = allAccountsWithMeta.find(
-    ({ address }) => address === selectedAccount,
-  )?.meta.name;
+  useEffect(() => {
+    const updateWrapperWidth = () => {
+      const keyName = allAccountsWithMeta.find(
+        ({ address }) => address === selectedAccount,
+      )?.meta.name;
+      setSelectedKeyName(keyName ?? '');
+    };
+
+    updateWrapperWidth();
+  }, [selectedAccount, allAccountsWithMeta]);
+
+  const wrapperWidth = ref.current?.clientWidth ?? 150;
+  const truncateLength = Math.floor((wrapperWidth - 100) / 11);
+  const truncatedSelectedKeyName = truncateText(
+    selectedKeyName,
+    truncateLength,
+  );
 
   return (
     <StyledWrapper>
@@ -32,14 +49,10 @@ export const KeyInfo = () => {
           <Icon name="KeyIcon" className="key-icon" size="26px" />
         </IconWrapper>
       )}
-      <div className="info-wrapper">
+      <div className="info-wrapper" ref={ref}>
         <Text marginBottom={4}>
-          Selected key
-          {selectedKeyName ? (
-            <>
-              : <span className="key-name">{selectedKeyName}</span>
-            </>
-          ) : null}
+          Selected key:{' '}
+          <span className="key-name">{truncatedSelectedKeyName}</span>
         </Text>
         <KeyInfoWrapper>
           {!identityLoading && (
@@ -61,7 +74,7 @@ export const KeyInfo = () => {
                 )}
             </>
           )}
-          <WalletSelect placement="widget" trimValue={false} />
+          <WalletSelect placement="widget" />
           <IconWrapper>
             {selectedAccount ? (
               <CopyToClipboard value={selectedAccount} />

--- a/src/layouts/Overview/components/KeyInfo/styles.ts
+++ b/src/layouts/Overview/components/KeyInfo/styles.ts
@@ -13,6 +13,7 @@ export const StyledWrapper = styled.div`
 
   & .info-wrapper {
     flex-grow: 1;
+    white-space: nowrap;
 
     & > p {
       color: rgba(255, 255, 255, 0.82);
@@ -22,10 +23,9 @@ export const StyledWrapper = styled.div`
   & .key-name {
     color: #ffffff;
     font-weight: 500;
-    text-transform: uppercase;
   }
 
-  @media screen and (max-width: 1024px) {
+  @media screen and (max-width: 1023px) {
     width: 100%;
   }
 `;

--- a/src/layouts/Portfolio/components/AssetAllocation/index.tsx
+++ b/src/layouts/Portfolio/components/AssetAllocation/index.tsx
@@ -187,7 +187,7 @@ export const AssetAllocation = () => {
                 onMouseLeave={() => setOtherAssetsExpanded(false)}
               >
                 {ticker}
-                <span>{formatBalance(percentage)}%</span>
+                <span>{formatBalance(percentage, 2)}%</span>
                 {otherAssetsExpanded && (
                   <StyledExpandedOtherAssets>
                     {smallAmountAssets.map((option) => (
@@ -196,7 +196,7 @@ export const AssetAllocation = () => {
                         color={option.color}
                       >
                         {option.ticker}
-                        <span>{formatBalance(option.percentage)}%</span>
+                        <span>{formatBalance(option.percentage, 2)}%</span>
                       </StyledLegendItem>
                     ))}
                   </StyledExpandedOtherAssets>
@@ -205,7 +205,7 @@ export const AssetAllocation = () => {
             ) : (
               <StyledLegendItem key={ticker} color={color}>
                 {ticker}
-                <span>{formatBalance(percentage)}%</span>
+                <span>{formatBalance(percentage, 2)}%</span>
               </StyledLegendItem>
             );
           })

--- a/src/layouts/Portfolio/components/AssetTable/config.tsx
+++ b/src/layouts/Portfolio/components/AssetTable/config.tsx
@@ -35,7 +35,7 @@ export const columns = {
       enableSorting: true,
       cell: (info) => {
         const percentage = info.getValue();
-        return `${formatBalance(percentage)}%`;
+        return `${formatBalance(percentage, 2)}%`;
       },
     }),
     tokenColumnHelper.accessor('balance', {

--- a/src/layouts/Settings/components/BlockedWallets/index.tsx
+++ b/src/layouts/Settings/components/BlockedWallets/index.tsx
@@ -69,7 +69,7 @@ export const BlockedWallets = () => {
           {blockedWallets.map((wallet) => (
             <StyledWalletWrapper key={wallet}>
               <Text size="large" bold>
-                {formatKey(wallet)}
+                {formatKey(wallet, 10, 10)}
               </Text>
               <StyledActionButton onClick={() => unblockWalletAddress(wallet)}>
                 Unblock

--- a/src/layouts/Settings/components/DefaultAddress/index.tsx
+++ b/src/layouts/Settings/components/DefaultAddress/index.tsx
@@ -33,7 +33,7 @@ export const DefaultAddress = () => {
       <StyledValue onClick={toggleModal}>
         {defaultAccount ? (
           <>
-            {formatKey(defaultAccount)}
+            {formatKey(defaultAccount, 8, 8)}
             {!allAccounts.includes(defaultAccount) &&
               !blockedWallets.includes(defaultAccount) && (
                 <StyledLabel>Not installed</StyledLabel>


### PR DESCRIPTION
This PR includes the following changes.
- POLYX Balances now show as Local Strings i.e. include thousand separator, with 6 decimals (unless specifically overridden)
- On the DID info card the identity ID shrinks / expands based on the available container space rather than page size
- For the wallet select component show Key name in header
- In the header items wrap to available space but notifications icon and key name always show on the same row
- For the wallet select component, when used in the overview page select key card, expand / shrink the address based on the available container space rather than page size
- truncate key name to available space in select key card (I couldn't get this to overflow so added a helper to truncate this text)
- truncate key names to available space in identity ID details modal
- multiple minor miscellaneous layout changes