### PR TITLE
nginx config update

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -12,6 +12,6 @@ server {
     }
 
     location / {
-        try_files $uri $uri/ /index.html;
+        try_files $uri /index.html;
     }
 }


### PR DESCRIPTION
drops `$uri/`, as no html should be served from nested paths; only `/index.html` - resolves 403 error on root-level assets other than `index.html`