### PR TITLE
favicon fixes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ node {
 
                                 set -eu -o pipefail
 
-                                umask 077 # mode: 0600
+                                umask 0077 # mode: 0600
 
                                 cleanup() {
                                     { shred ssh.json; sync; rm -f ssh.json; } || true
@@ -86,6 +86,8 @@ node {
                                 export GIT_SSH_COMMAND+=' -o StrictHostKeyChecking=yes'
                                 export GIT_SSH_COMMAND+=' -o CertificateFile=id_ed25519-cert.pub'
                                 export GIT_SSH_COMMAND+=' -o IdentityFile=id_ed25519'
+
+                                umask 0022 # mode: 0644
 
                                 git clone \
                                     --depth=1 \

--- a/nginx.conf
+++ b/nginx.conf
@@ -12,6 +12,6 @@ server {
     }
 
     location / {
-        try_files $uri /index.html;
+        try_files $uri $uri/ /index.html;
     }
 }


### PR DESCRIPTION
- fix: sets `umask` back to the default of `0022` (mode: 0644) after the ssh key/certificate-related files are provisioned, prior to cloning the repo
- revert: restores nginx nested directory existence check