### PR TITLE
Add support for system configured theme

### DIFF
--- a/src/components/AssetSelect/styles.ts
+++ b/src/components/AssetSelect/styles.ts
@@ -63,6 +63,7 @@ export const StyledExpandedSelect = styled.div`
   border-radius: 8px;
   z-index: 1;
   box-shadow: 0px 20px 40px rgba(30, 30, 30, 0.1);
+  overflow-y: auto;
 `;
 
 export const SelectedOption = styled.div`

--- a/src/context/ThemeContext/constants.ts
+++ b/src/context/ThemeContext/constants.ts
@@ -6,4 +6,6 @@ export enum Themes {
 export const initialValues = {
   currentTheme: Themes.Light,
   toggleTheme: () => {},
+  systemThemeEnabled: true,
+  toggleUseSystemTheme: () => {},
 };

--- a/src/context/ThemeContext/context.ts
+++ b/src/context/ThemeContext/context.ts
@@ -4,6 +4,8 @@ import { Themes, initialValues } from './constants';
 interface IThemeContext {
   currentTheme: `${Themes}`;
   toggleTheme: () => void;
+  systemThemeEnabled: boolean;
+  toggleUseSystemTheme: () => void;
 }
 
 const ThemeContext = createContext<IThemeContext>(initialValues);

--- a/src/context/ThemeContext/provider.tsx
+++ b/src/context/ThemeContext/provider.tsx
@@ -1,15 +1,25 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo, useCallback } from 'react';
 import ThemeContext from './context';
 import { Themes } from './constants';
 
 const darkThemeMq = window.matchMedia('(prefers-color-scheme: dark)');
 
-const getInitialTheme = () => {
+const isSystemThemeEnabled = (): boolean => {
+  const systemThemeEnabled = localStorage.getItem('useSystemTheme');
+  return systemThemeEnabled === 'true';
+};
+
+const getSystemTheme = (): Themes => {
+  const isDarkTheme = darkThemeMq.matches;
+  return isDarkTheme ? Themes.Dark : Themes.Light;
+};
+
+const getInitialTheme = (): Themes => {
   const themeFromLs = localStorage.getItem('theme') || null;
 
-  if (!themeFromLs) {
-    const isDarkTheme = darkThemeMq.matches;
-    return isDarkTheme ? Themes.Dark : Themes.Light;
+  if (isSystemThemeEnabled() || !themeFromLs) {
+    localStorage.setItem('useSystemTheme', 'true');
+    return getSystemTheme();
   }
 
   return themeFromLs as Themes;
@@ -20,29 +30,64 @@ interface IAppThemeProps {
 }
 
 const AppThemeProvider = ({ children }: IAppThemeProps) => {
-  const [currentTheme, setCurrentTheme] = useState(getInitialTheme);
+  const [currentTheme, setCurrentTheme] = useState<Themes>(
+    isSystemThemeEnabled() ? getSystemTheme() : getInitialTheme(),
+  );
+  const [systemThemeEnabled, setSystemThemeEnabled] = useState(
+    isSystemThemeEnabled(),
+  );
 
   useEffect(() => {
     localStorage.setItem('theme', currentTheme);
   }, [currentTheme]);
 
-  const toggleTheme = () => {
-    switch (currentTheme) {
-      case Themes.Light:
-        setCurrentTheme(Themes.Dark);
-        break;
-      case Themes.Dark:
-        setCurrentTheme(Themes.Light);
-        break;
-      default:
-        break;
-    }
-  };
+  useEffect(() => {
+    localStorage.setItem('useSystemTheme', systemThemeEnabled.toString());
+  }, [systemThemeEnabled]);
+
+  useEffect(() => {
+    const handleSystemThemeChange = () => {
+      if (isSystemThemeEnabled()) {
+        setCurrentTheme(getSystemTheme());
+      }
+    };
+
+    darkThemeMq.addEventListener('change', handleSystemThemeChange);
+
+    return () => {
+      darkThemeMq.removeEventListener('change', handleSystemThemeChange);
+    };
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setCurrentTheme((prevTheme) =>
+      prevTheme === Themes.Light ? Themes.Dark : Themes.Light,
+    );
+    setSystemThemeEnabled(false);
+  }, []);
+
+  const toggleUseSystemTheme = useCallback(() => {
+    setCurrentTheme((prevTheme) => {
+      const updatedUseSystemTheme = !isSystemThemeEnabled();
+      setSystemThemeEnabled(updatedUseSystemTheme);
+      return updatedUseSystemTheme ? getSystemTheme() : prevTheme;
+    });
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({
+      currentTheme,
+      toggleTheme,
+      systemThemeEnabled,
+      toggleUseSystemTheme,
+    }),
+    [currentTheme, toggleTheme, systemThemeEnabled, toggleUseSystemTheme],
+  );
 
   return (
     <ThemeContext.Provider
       // eslint-disable-next-line react/jsx-no-constructed-context-values
-      value={{ currentTheme, toggleTheme }}
+      value={contextValue}
     >
       {children}
     </ThemeContext.Provider>

--- a/src/layouts/Settings/components/ThemeToggle/index.tsx
+++ b/src/layouts/Settings/components/ThemeToggle/index.tsx
@@ -6,28 +6,54 @@ import {
   StyledCheckboxMark,
   StyledCheckboxWrapper,
   StyledWrapper,
+  StyledSelect,
 } from './styles';
 
 export const ThemeToggle = () => {
-  const { currentTheme, toggleTheme } = useContext(ThemeContext);
+  const {
+    currentTheme,
+    toggleTheme,
+    systemThemeEnabled,
+    toggleUseSystemTheme,
+  } = useContext(ThemeContext);
   const isLight = currentTheme === 'light';
+
+  const handleThemeCheckboxChange = () => {
+    toggleTheme();
+  };
+
+  const handleSystemThemeCheckboxChange = () => {
+    toggleUseSystemTheme();
+  };
+
   return (
     <StyledWrapper>
-      {currentTheme}
-      <StyledCheckboxWrapper isLight={isLight} htmlFor="theme-toggle">
-        <HiddenInput
-          type="checkbox"
-          id="theme-toggle"
-          onChange={() => toggleTheme()}
-        />
-        <StyledCheckboxMark isLight={isLight}>
-          <Icon
-            name={isLight ? 'LightMode' : 'DarkMode'}
-            size="12px"
-            className={`icon ${isLight ? 'light' : 'dark'}`}
+      <div>
+        System Default
+        <StyledSelect
+          isSelected={systemThemeEnabled}
+          onClick={handleSystemThemeCheckboxChange}
+        >
+          <Icon name="Check" size="16px" />
+        </StyledSelect>
+      </div>
+      <div>
+        {currentTheme}
+        <StyledCheckboxWrapper isLight={isLight} htmlFor="theme-toggle">
+          <HiddenInput
+            type="checkbox"
+            id="theme-toggle"
+            onChange={handleThemeCheckboxChange}
           />
-        </StyledCheckboxMark>
-      </StyledCheckboxWrapper>
+          <StyledCheckboxMark isLight={isLight}>
+            <Icon
+              name={isLight ? 'LightMode' : 'DarkMode'}
+              size="12px"
+              className={`icon ${isLight ? 'light' : 'dark'}`}
+            />
+          </StyledCheckboxMark>
+        </StyledCheckboxWrapper>
+      </div>
     </StyledWrapper>
   );
 };

--- a/src/layouts/Settings/components/ThemeToggle/styles.ts
+++ b/src/layouts/Settings/components/ThemeToggle/styles.ts
@@ -2,10 +2,18 @@ import styled from 'styled-components';
 
 export const StyledWrapper = styled.div`
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
+  row-gap: 6px;
+  column-gap: 16px;
   text-transform: capitalize;
+
+  > div {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
 `;
 
 export const StyledCheckboxWrapper = styled.label<{ isLight: boolean }>`
@@ -31,7 +39,8 @@ export const StyledCheckboxMark = styled.span<{ isLight: boolean }>`
   height: 16px;
   background-color: ${({ isLight }) => (isLight ? '#ffffff' : '#FF2E72')};
   border-radius: 50%;
-  box-shadow: ${({ theme }) => `0px 1px 3px ${theme.colors.shadow},
+  box-shadow: ${({ theme }) =>
+    `0px 1px 3px ${theme.colors.shadow},
     0px 1px 2px ${theme.colors.shadow}`};
   transition: background-color 250ms ease-out, left 250ms ease-out;
 
@@ -58,4 +67,21 @@ export const HiddenInput = styled.input`
   clip-path: inset(100%);
   clip: rect(0 0 0 0);
   overflow: hidden;
+`;
+
+export const StyledSelect = styled.div<{ isSelected: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background-color: ${({ isSelected }) =>
+    isSelected ? '#FF2E72' : 'transparent'};
+  border: 2px solid
+    ${({ isSelected, theme }) =>
+      isSelected ? '#FF2E72' : theme.colors.textDisabled};
+  color: ${({ isSelected }) => (isSelected ? '#FFFFFF' : 'transparent')};
+  transition: background-color 250ms ease-out, color 250ms ease-out;
+  cursor: pointer;
 `;


### PR DESCRIPTION
Adds optional setting to use system configured theme. Theme can either be manually set in the browse or dynamically update based on changes to the system theme (set by default on initial visit).
![image](https://github.com/PolymeshAssociation/polymesh-portal/assets/42175565/0bb47cbc-aac1-427c-b6ce-9a326537b376)
![image](https://github.com/PolymeshAssociation/polymesh-portal/assets/42175565/93fd37b8-aa5b-4836-a9da-56881fa71921)

