### PR TITLE
Rate limit reward history download & label all wallet keys

### DIFF
--- a/src/components/Sidebar/styles.ts
+++ b/src/components/Sidebar/styles.ts
@@ -8,6 +8,7 @@ export const StyledSidebar = styled.aside<{
   display: flex;
   flex-direction: column;
   width: ${({ $fullWidth }) => ($fullWidth ? '256px' : '88px')};
+  min-width: ${({ $fullWidth }) => ($fullWidth ? '256px' : '88px')};
   padding: 36px 16px;
   background-color: ${({ theme }) => theme.colors.dashboardBackground};
 

--- a/src/components/WalletSelect/index.tsx
+++ b/src/components/WalletSelect/index.tsx
@@ -21,6 +21,7 @@ const WalletSelect: React.FC<ISelectProps> = ({ placement = 'header' }) => {
     allAccountsWithMeta,
     primaryKey,
     secondaryKeys,
+    keyIdentityRelationships,
   } = useContext(AccountContext);
   const [expanded, setExpanded] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -126,12 +127,16 @@ const WalletSelect: React.FC<ISelectProps> = ({ placement = 'header' }) => {
                   <span className="meta">{meta.name || ''}</span>
                   <span className="key">{formatKey(address, 8, 7)}</span>
                 </span>
-                {address === primaryKey ? (
-                  <StyledKeyLabel $primary>Primary</StyledKeyLabel>
-                ) : null}
-                {secondaryKeys.includes(address) ? (
-                  <StyledKeyLabel>Second.</StyledKeyLabel>
-                ) : null}
+                <StyledKeyLabel
+                  $primary={keyIdentityRelationships[address] === 'Primary'}
+                  $selectedId={
+                    address === selectedAccount ||
+                    address === primaryKey ||
+                    secondaryKeys.includes(address)
+                  }
+                >
+                  {keyIdentityRelationships[address]}
+                </StyledKeyLabel>
                 <StyledInput
                   type="radio"
                   name="key"

--- a/src/components/WalletSelect/index.tsx
+++ b/src/components/WalletSelect/index.tsx
@@ -104,17 +104,18 @@ const WalletSelect: React.FC<ISelectProps> = ({ placement = 'header' }) => {
       {expanded && (
         <StyledExpandedSelect $placement={placement}>
           {allAccountsWithMeta
-            .sort(({ address }) => (address === selectedAccount ? -1 : 1))
             .sort((a, b) => {
-              if (
-                a.address === primaryKey &&
-                !secondaryKeys.includes(b.address)
-              )
-                return -1;
-              if (secondaryKeys.includes(a.address) && b.address !== primaryKey)
-                return -1;
+              // place selected key first
+              if (a.address === selectedAccount) return -1;
+              if (b.address === selectedAccount) return 1;
+              // place primary key of selected key identity next
+              if (a.address === primaryKey) return -1;
+              if (b.address === primaryKey) return 1;
+              // place secondary keys next of selected key identity next
+              if (secondaryKeys.includes(a.address)) return -1;
+              if (secondaryKeys.includes(b.address)) return 1;
 
-              return 1;
+              return 0;
             })
             .map(({ address, meta }) => (
               <StyledLabel

--- a/src/components/WalletSelect/styles.ts
+++ b/src/components/WalletSelect/styles.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { ESelectPlacements } from './types';
 
 export const StyledSelectWrapper = styled.div<{
@@ -86,8 +86,8 @@ export const StyledExpandedSelect = styled.div<{
     $placement === ESelectPlacements.HEADER
       ? `
       top: 120%;
-      right: -25px;
-      width: 250px;
+      right: -76px;
+      width: 300px;
       `
       : ''}
   ${({ $placement }) =>
@@ -96,7 +96,7 @@ export const StyledExpandedSelect = styled.div<{
       top: 110%;
       right: -40px;
       width: calc(100% + 40px);
-      min-width: 280px;
+      min-width: 300px;
       text-align: center;
       `
       : ''}
@@ -145,7 +145,7 @@ export const StyledLabel = styled.label<{
     align-items: flex-start;
     font-size: ${({ $placement }) =>
       $placement === ESelectPlacements.HEADER ? '12px' : '14px'};
-    max-width: calc(100% - 63px);
+    max-width: calc(100% - 102px);
 
     & .meta {
       white-space: nowrap;
@@ -179,17 +179,39 @@ export const IconWrapper = styled.div`
   justify-content: center;
 `;
 
-export const StyledKeyLabel = styled.div<{ $primary?: boolean }>`
+export const StyledKeyLabel = styled.div<{
+  $primary?: boolean;
+  $selectedId?: boolean;
+}>`
   display: flex;
   align-items: center;
   justify-content: center;
-  min-width: 63px;
   height: 24px;
   padding: 0 8px;
   border-radius: 100px;
   font-size: 12px;
-  ${({ $primary, theme }) =>
-    $primary
-      ? `border: 1px solid #fad1dc; color: ${theme.colors.textPink};`
-      : `border: 1px solid #F2EFFF; color: ${theme.colors.textBlue};`};
+  ${({ $primary, $selectedId, theme }) => {
+    if ($primary) {
+      if ($selectedId)
+        return css`
+          color: #ff2e72;
+          font-weight: 500;
+          background-color: #fad1dc;
+        `;
+      return css`
+        border: 1px solid ${theme.colors.textPink};
+        color: ${theme.colors.textPink};
+      `;
+    }
+    if ($selectedId)
+      return css`
+        color: #170087;
+        font-weight: 500;
+        background-color: #dcd3ff;
+      `;
+    return css`
+      border: 1px solid ${theme.colors.textBlue};
+      color: ${theme.colors.textBlue};
+    `;
+  }}
 `;

--- a/src/context/AccountContext/constants.ts
+++ b/src/context/AccountContext/constants.ts
@@ -4,15 +4,20 @@ import {
   MultiSig,
   MultiSigDetails,
 } from '@polymeshassociation/polymesh-sdk/types';
-import type { AccountIdentityRelation } from '@polymeshassociation/polymesh-sdk/api/entities/Account/types';
+import type {
+  AccountIdentityRelation,
+  AccountKeyType,
+} from '@polymeshassociation/polymesh-sdk/api/entities/Account/types';
 import type { InjectedAccountWithMeta } from '@polkadot/extension-inject/types';
 
 export interface IInfoByKey {
-  key: string;
-  totalBalance: string;
   available: boolean;
   isMultiSig: boolean;
+  key: string;
+  keyIdentityRelationship: AccountIdentityRelation;
+  keyType: AccountKeyType;
   multisigDetails: MultiSigDetails | null;
+  totalBalance: string;
 }
 
 export interface IAccountContext {

--- a/src/context/AccountContext/constants.ts
+++ b/src/context/AccountContext/constants.ts
@@ -4,8 +4,8 @@ import {
   MultiSig,
   MultiSigDetails,
 } from '@polymeshassociation/polymesh-sdk/types';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { InjectedAccountWithMeta } from '@polkadot/extension-inject/types';
+import type { AccountIdentityRelation } from '@polymeshassociation/polymesh-sdk/api/entities/Account/types';
+import type { InjectedAccountWithMeta } from '@polkadot/extension-inject/types';
 
 export interface IInfoByKey {
   key: string;
@@ -36,6 +36,7 @@ export interface IAccountContext {
   identityHasValidCdd: boolean;
   accountIsMultisigSigner: boolean;
   refreshAccountIdentity: () => void;
+  keyIdentityRelationships: Record<string, AccountIdentityRelation>;
 }
 
 export const initialState = {
@@ -59,4 +60,5 @@ export const initialState = {
   identityHasValidCdd: false,
   accountIsMultisigSigner: false,
   refreshAccountIdentity: () => {},
+  keyIdentityRelationships: {},
 };

--- a/src/context/AccountContext/provider.tsx
+++ b/src/context/AccountContext/provider.tsx
@@ -330,7 +330,7 @@ const AccountProvider = ({ children }: IProviderProps) => {
 
   // Get total balance for all keys associated with current DID
   useEffect(() => {
-    if (!sdk || !primaryKey) return;
+    if (!sdk || !primaryKey || identityLoading) return;
 
     (async () => {
       const balancesByKey = await Promise.all(
@@ -367,7 +367,7 @@ const AccountProvider = ({ children }: IProviderProps) => {
 
       setAllKeyInfo(balancesByKey);
     })();
-  }, [allAccounts, primaryKey, sdk, secondaryKeys]);
+  }, [allAccounts, identityLoading, primaryKey, sdk, secondaryKeys]);
 
   const blockWalletAddress = useCallback(
     (address: string) => {

--- a/src/layouts/Overview/components/DidInfo/components/Details/index.tsx
+++ b/src/layouts/Overview/components/DidInfo/components/Details/index.tsx
@@ -184,10 +184,12 @@ export const Details: React.FC<IDetailsProps> = ({
                 <StyledKeyData key={key}>
                   <KeyInfo>
                     <div className="name-container">
-                      {keyName && (
+                      {keyName ? (
                         <Text bold truncateOverflow>
                           {keyName}
                         </Text>
+                      ) : (
+                        ''
                       )}
                     </div>
                     <div className="status-container">

--- a/src/layouts/Overview/components/DidInfo/components/Details/index.tsx
+++ b/src/layouts/Overview/components/DidInfo/components/Details/index.tsx
@@ -1,6 +1,10 @@
 import { useContext, useState } from 'react';
 import { UnsubCallback } from '@polymeshassociation/polymesh-sdk/types';
 import { Account } from '@polymeshassociation/polymesh-sdk/internal';
+import {
+  AccountIdentityRelation,
+  AccountKeyType,
+} from '@polymeshassociation/polymesh-sdk/api/entities/Account/types';
 import { AccountContext } from '~/context/AccountContext';
 import { Modal, Icon, CopyToClipboard } from '~/components';
 import { Button, Heading, Text } from '~/components/UiKit';
@@ -162,8 +166,17 @@ export const Details: React.FC<IDetailsProps> = ({
             return 0;
           })
           .map(
-            ({ key, totalBalance, available, isMultiSig, multisigDetails }) => {
-              const isPrimaryKey = key === primaryKey;
+            ({
+              available,
+              isMultiSig,
+              key,
+              keyIdentityRelationship,
+              keyType,
+              multisigDetails,
+              totalBalance,
+            }) => {
+              const isPrimaryKey =
+                keyIdentityRelationship === AccountIdentityRelation.Primary;
               const keyName = allAccountsWithMeta.find(
                 ({ address }) => address === key,
               )?.meta.name;
@@ -190,15 +203,18 @@ export const Details: React.FC<IDetailsProps> = ({
                           )}
                         </StyledLabel>
                       )}
-                      {isMultiSig && multisigDetails && (
-                        <StyledLabel>
-                          {multisigDetails.requiredSignatures.toNumber()} of{' '}
-                          {multisigDetails.signers.length} MultiSig
-                        </StyledLabel>
-                      )}
+                      {keyType !== AccountKeyType.Normal &&
+                        (multisigDetails ? (
+                          <StyledLabel>
+                            {multisigDetails.requiredSignatures.toNumber()} of{' '}
+                            {multisigDetails.signers.length} {keyType}
+                          </StyledLabel>
+                        ) : (
+                          <StyledLabel>{keyType}</StyledLabel>
+                        ))}
                       {isMobile && (
                         <StyledLabel $isPrimary={isPrimaryKey}>
-                          {isPrimaryKey ? 'Primary' : 'Secondary'}
+                          {keyIdentityRelationship}
                         </StyledLabel>
                       )}
                       {primaryIsSelected && !isPrimaryKey && (
@@ -224,7 +240,7 @@ export const Details: React.FC<IDetailsProps> = ({
                     </StyledBalance>
                     {!isMobile && (
                       <StyledLabel $isPrimary={isPrimaryKey}>
-                        {isPrimaryKey ? 'Primary' : 'Secondary'}
+                        {keyIdentityRelationship}
                       </StyledLabel>
                     )}
                   </KeyDetails>

--- a/src/layouts/Overview/components/DidInfo/components/Details/styles.ts
+++ b/src/layouts/Overview/components/DidInfo/components/Details/styles.ts
@@ -119,16 +119,19 @@ export const KeyInfo = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
 
   .name-container {
     min-width: 100px;
     padding-right: 8px;
+    margin-left: 0;
   }
 
   .status-container {
     display: flex;
     align-items: center;
     gap: 8px;
+    margin-left: auto;
   }
 `;
 
@@ -172,6 +175,7 @@ export const StyledLabel = styled.div<{
   border-radius: 100px;
   font-weight: 500;
   font-size: 12px;
+  white-space: nowrap;
   ${({ $isPrimary, theme }) =>
     $isPrimary
       ? `
@@ -215,7 +219,9 @@ export const StyledSelect = styled.div<{ $isSelected: boolean }>`
       $isSelected ? theme.colors.textPink : theme.colors.textDisabled};
   color: ${({ $isSelected, theme }) =>
     $isSelected ? theme.colors.landingBackground : 'transparent'};
-  transition: background-color 250ms ease-out, border 250ms ease-out,
+  transition:
+    background-color 250ms ease-out,
+    border 250ms ease-out,
     color 250ms ease-out;
   cursor: pointer;
 `;

--- a/src/layouts/Overview/components/KeyInfo/index.tsx
+++ b/src/layouts/Overview/components/KeyInfo/index.tsx
@@ -12,14 +12,8 @@ import { useWindowWidth } from '~/hooks/utility';
 import { truncateText } from '~/helpers/formatters';
 
 export const KeyInfo = () => {
-  const {
-    selectedAccount,
-    allAccountsWithMeta,
-    primaryKey,
-    secondaryKeys,
-    accountIsMultisigSigner,
-    identityLoading,
-  } = useContext(AccountContext);
+  const { selectedAccount, allAccountsWithMeta, keyIdentityRelationships } =
+    useContext(AccountContext);
   const { isMobile, isSmallDesktop } = useWindowWidth();
   const ref = useRef<HTMLDivElement>(null);
   const [selectedKeyName, setSelectedKeyName] = useState('');
@@ -77,24 +71,18 @@ export const KeyInfo = () => {
           <span className="key-name">{truncatedSelectedKeyName}</span>
         </Text>
         <KeyInfoWrapper>
-          {!identityLoading && (
-            <>
-              {selectedAccount && selectedAccount === primaryKey && (
-                <StyledLabel>Primary</StyledLabel>
-              )}
-              {secondaryKeys.includes(selectedAccount) && (
-                <StyledLabel>Secondary</StyledLabel>
-              )}
-              {accountIsMultisigSigner && (
-                <StyledLabel>MultiSig Signer</StyledLabel>
-              )}
-              {selectedAccount &&
-                selectedAccount !== primaryKey &&
-                !secondaryKeys.includes(selectedAccount) &&
-                !accountIsMultisigSigner && (
-                  <StyledLabel>Unassigned</StyledLabel>
-                )}
-            </>
+          {selectedAccount && keyIdentityRelationships[selectedAccount] ? (
+            <StyledLabel>
+              {keyIdentityRelationships[selectedAccount]}
+            </StyledLabel>
+          ) : (
+            <SkeletonLoader
+              containerClassName="loader"
+              height="32px"
+              width="91px"
+              baseColor="rgba(255,255,255,0.05)"
+              highlightColor="rgba(255, 255, 255, 0.24)"
+            />
           )}
           <WalletSelect placement="widget" />
           <IconWrapper>

--- a/src/layouts/Staking/components/RewardsTable/hooks.tsx
+++ b/src/layouts/Staking/components/RewardsTable/hooks.tsx
@@ -269,8 +269,8 @@ export const useRewardTable = (
         throw new Error('unknown currentTab value');
       }
 
-      const rateLimit = 6; // Number of queries per second
-      const delay = 1000 / rateLimit; // Delay in milliseconds between queries
+      const maxPagesPerSecond = 6;
+      const delay = 1000 / maxPagesPerSecond; // Delay in milliseconds between queries
 
       for (let page = 0; page < pageCount; page += 1) {
         const queryOpts = {
@@ -282,7 +282,7 @@ export const useRewardTable = (
         promises.push(
           (async () => {
             await new Promise((resolve) => {
-              setTimeout(resolve, page < rateLimit ? 0 : page * delay);
+              setTimeout(resolve, page < maxPagesPerSecond ? 0 : page * delay);
             });
 
             return gqlClient

--- a/src/layouts/Staking/components/StakingAccountInfo/index.tsx
+++ b/src/layouts/Staking/components/StakingAccountInfo/index.tsx
@@ -328,8 +328,9 @@ export const StakingAccountInfo = () => {
         <StyledTextWrapper>
           <Text size="medium">
             The selected key is not currently staking. Click the button below to
-            open the staking interface where you can Bond POLYX to a Stash key,
-            Nominated them to Node Operators and start earning staking rewards.
+            open the staking interface where you can bond POLYX tokens to a
+            stash key, nominate them to node operators and start earning staking
+            rewards.
           </Text>
         </StyledTextWrapper>
         {goToStakingButton}

--- a/src/layouts/Staking/styles.ts
+++ b/src/layouts/Staking/styles.ts
@@ -10,7 +10,7 @@ export const OverviewGrid = styled.div`
 
   @media screen and (min-width: 1200px) {
     display: grid;
-    grid-template-columns: minmax(468px, auto) minmax(350px, auto); //minmax(468px, auto) auto;
+    grid-template-columns: minmax(468px, 1fr) minmax(350px, 0.8fr);
     align-items: stretch;
     gap: 16px;
     grid-template-areas:


### PR DESCRIPTION
- Rate limit reward history page downloads
- Add labels for all wallet keys
- Fix key sort order so selected is always first (selected, primary of selected DID, secondary keys of selected DID, others)
- Add key type and relationship from the SDK to the selected identity to all key info. This adds types for Smart contracts not previously included.
- Fix issue where keys in the details modal sometime were not for the selected identity.
- Minor style adjustments to identity details modal
- Fixed content debounce during sidebar navigation for unassigned wallets