### PR TITLE
Fix: Attempt to prevent redirects to the Landing Page when `defaultExtension` is set

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@hookform/resolvers": "^2.9.11",
     "@polkadot/util-crypto": "12.4.2",
     "@polymeshassociation/browser-extension-signing-manager": "^2.2.0",
-    "@polymeshassociation/polymesh-sdk": "23.0.0-alpha.9",
+    "@polymeshassociation/polymesh-sdk": "23.0.0-alpha.13",
     "@tanstack/react-table": "^8.7.9",
     "events": "^3.3.0",
     "graphql": "^16.8.0",
@@ -50,7 +50,7 @@
     "eslint-plugin-react-hooks": "^4.3.0",
     "prettier": "^3.0.3",
     "rollup-plugin-polyfill-node": "^0.12.0",
-    "typescript": "^4.9.3",
+    "typescript": "^5.2.2",
     "vite": "^4.1.0",
     "vite-tsconfig-paths": "^4.0.5"
   },

--- a/src/context/PolymeshContext/provider.tsx
+++ b/src/context/PolymeshContext/provider.tsx
@@ -17,7 +17,6 @@ interface IChainMetadata {
     timestamp: string;
   };
 }
-const injectedExtensions = BrowserExtensionSigningManager.getExtensionList();
 
 const PolymeshProvider = ({ children }: IProviderProps) => {
   const [sdk, setSdk] = useState<Polymesh | null>(null);
@@ -154,6 +153,9 @@ const PolymeshProvider = ({ children }: IProviderProps) => {
     ) {
       window.location.reload();
     }
+
+    const injectedExtensions =
+      BrowserExtensionSigningManager.getExtensionList();
 
     if (
       !defaultExtension ||

--- a/src/hooks/utility/useLocalStorage.tsx
+++ b/src/hooks/utility/useLocalStorage.tsx
@@ -20,17 +20,11 @@ const useLocalStorage = <T,>(
   });
 
   useEffect(() => {
-    if (storedValue == null || typeof window === undefined) return;
+    if (storedValue == null || typeof window === 'undefined') return;
 
     window.localStorage.setItem(key, JSON.stringify(storedValue));
   }, [key, storedValue]);
 
-  // const setValue = (value: T) => {
-  //   setStoredValue(value);
-  //   if (typeof window !== 'undefined') {
-  //     window.localStorage.setItem(key, JSON.stringify(value));
-  //   }
-  // };
   return [storedValue, setStoredValue];
 };
 

--- a/src/layouts/Settings/components/DefaultWallet/index.tsx
+++ b/src/layouts/Settings/components/DefaultWallet/index.tsx
@@ -1,16 +1,18 @@
-import { useContext, useState } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import { BrowserExtensionSigningManager } from '@polymeshassociation/browser-extension-signing-manager';
 import { PolymeshContext } from '~/context/PolymeshContext';
 import { ExtensionSelect } from '~/components';
 import { StyledLabel, StyledValue } from './styles';
-
-const injectedExtensions = BrowserExtensionSigningManager.getExtensionList();
 
 export const DefaultWallet = () => {
   const {
     settings: { defaultExtension },
   } = useContext(PolymeshContext);
   const [modalOpen, setModalOpen] = useState(false);
+
+  const injectedExtensions = useMemo(() => {
+    return BrowserExtensionSigningManager.getExtensionList();
+  }, []);
 
   return (
     <>

--- a/src/layouts/SharedLayout/index.tsx
+++ b/src/layouts/SharedLayout/index.tsx
@@ -21,7 +21,7 @@ const SharedLayout: React.FC<ILayoutProps> = ({ children }) => {
   const { pathname } = useLocation();
   const isLandingPage = pathname === '/';
   const redirectToLanding =
-    !defaultExtension && !isLandingPage && !connecting && !initialized;
+    !defaultExtension && !isLandingPage && connecting === false && !initialized;
 
   useEffect(() => {
     if (!isMobile) {
@@ -75,7 +75,7 @@ const SharedLayout: React.FC<ILayoutProps> = ({ children }) => {
           </div>
         </StyledPageWrapper>
       )}
-      {!isLandingPage && redirectToLanding && <Navigate to="/" replace />}
+      {redirectToLanding && <Navigate to="/" replace />}
     </>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1980,10 +1980,10 @@
     "@polkadot/util-crypto" "^12.4.2"
     "@polymeshassociation/signing-manager-types" "^3.1.0"
 
-"@polymeshassociation/polymesh-sdk@23.0.0-alpha.9":
-  version "23.0.0-alpha.9"
-  resolved "https://registry.yarnpkg.com/@polymeshassociation/polymesh-sdk/-/polymesh-sdk-23.0.0-alpha.9.tgz#7e76bf7611e9308923b47d0e200e1102985bc4bd"
-  integrity sha512-GKMyvoElmwf1R/zA6MmbvTDqi+oVqaUA6ZduDJt1hpLLQQzat55hE7ZmEbDsZ/iPzFtpjyiMre1WW+0jorQkNg==
+"@polymeshassociation/polymesh-sdk@23.0.0-alpha.13":
+  version "23.0.0-alpha.13"
+  resolved "https://registry.yarnpkg.com/@polymeshassociation/polymesh-sdk/-/polymesh-sdk-23.0.0-alpha.13.tgz#b2b20dd9f8f95cdf335cd1783e24cf7992f33a27"
+  integrity sha512-VgrWIVhfQzwLkY5UAginq7A2EM4N/doVbmP4OKwrtNA1valJxJ+1eALgLMgMGCe7iKK4XR4o0VqFsfvTVOAaGQ==
   dependencies:
     "@apollo/client" "^3.8.1"
     "@polkadot/api" "10.9.1"
@@ -5216,10 +5216,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.9.3:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
### Problem Description
Some users have reported that when they try to initially load the Portal it redirects them to the landing page even when they already have a `defaultExtension` set. When on the Landing page the Connect button is disabled for the selected default extension. The only way the page should redirect is if there is no `defaultExtension`. This suggests that in some cases `defaultExtension` is being attempted to be read from Local Storage before the window object is available.
![image](https://github.com/PolymeshAssociation/polymesh-portal/assets/42175565/123201f4-c6ba-44e2-991e-9730e0a438b5)

### Fix details

- change `!connecting` to `connecting === false` in redirectToLanding check. As connecting is initialized to `null` and only set to false if initial pre-connection checks fail in a `useEffect`, it should require page to have loaded and `defaultExtension` to be available from local storage to have been available.
- On the wallet selection modal enable the "Connect" button when SDK has not initialized even if the default extension is selected. This will allow a recovery option by clicking the `Connect` button if the above fix doesn't work.