### PR TITLE
Feature: Remember Last Selected Wallet

### DIFF
--- a/src/context/AccountContext/provider.tsx
+++ b/src/context/AccountContext/provider.tsx
@@ -42,6 +42,9 @@ const AccountProvider = ({ children }: IProviderProps) => {
     'defaultAccount',
     '',
   );
+  const rememberSelectedAccount = localStorage.getItem(
+    'rememberSelectedAccount',
+  );
   const [blockedWallets, setBlockedWallets] = useLocalStorage<string[]>(
     'blockedWallets',
     [],
@@ -166,6 +169,12 @@ const AccountProvider = ({ children }: IProviderProps) => {
     }
     setSelectedAccount(allAccounts[0]);
   }, [allAccounts, defaultAccount, selectedAccount]);
+
+  useEffect(() => {
+    if (rememberSelectedAccount === 'true' && selectedAccount) {
+      setDefaultAccount(selectedAccount);
+    }
+  }, [rememberSelectedAccount, selectedAccount, setDefaultAccount]);
 
   // Set account instance when selected account changes
   useEffect(() => {

--- a/src/context/AccountContext/provider.tsx
+++ b/src/context/AccountContext/provider.tsx
@@ -42,9 +42,6 @@ const AccountProvider = ({ children }: IProviderProps) => {
     'defaultAccount',
     '',
   );
-  const rememberSelectedAccount = localStorage.getItem(
-    'rememberSelectedAccount',
-  );
   const [blockedWallets, setBlockedWallets] = useLocalStorage<string[]>(
     'blockedWallets',
     [],
@@ -171,10 +168,13 @@ const AccountProvider = ({ children }: IProviderProps) => {
   }, [allAccounts, defaultAccount, selectedAccount]);
 
   useEffect(() => {
+    const rememberSelectedAccount = localStorage.getItem(
+      'rememberSelectedAccount',
+    );
     if (rememberSelectedAccount === 'true' && selectedAccount) {
       setDefaultAccount(selectedAccount);
     }
-  }, [rememberSelectedAccount, selectedAccount, setDefaultAccount]);
+  }, [selectedAccount, setDefaultAccount]);
 
   // Set account instance when selected account changes
   useEffect(() => {

--- a/src/layouts/Settings/components/DefaultAddress/index.tsx
+++ b/src/layouts/Settings/components/DefaultAddress/index.tsx
@@ -1,49 +1,83 @@
 import { useContext, useState } from 'react';
 import { Icon, Modal } from '~/components';
-import { Heading, Button, DropdownSelect } from '~/components/UiKit';
+import { Heading, Button, DropdownSelect, Text } from '~/components/UiKit';
 import { AccountContext } from '~/context/AccountContext';
 import { formatKey } from '~/helpers/formatters';
-import { useWindowWidth } from '~/hooks/utility';
+import { useLocalStorage, useWindowWidth } from '~/hooks/utility';
 import {
   StyledValue,
   StyledButtonWrapper,
   StyledLabel,
   StyledActionButton,
+  StyledRememberSelected,
+  StyledSelect,
 } from './styles';
 
 export const DefaultAddress = () => {
-  const { defaultAccount, setDefaultAccount, allAccounts, blockedWallets } =
-    useContext(AccountContext);
+  const {
+    selectedAccount,
+    defaultAccount,
+    setDefaultAccount,
+    allAccounts,
+    blockedWallets,
+  } = useContext(AccountContext);
+  const [rememberSelectedAccount, setRememberSelectedAccount] = useLocalStorage(
+    'rememberSelectedAccount',
+    false,
+  );
+  const [shouldRemember, setShouldRemember] = useState(rememberSelectedAccount);
   const [addressSelectExpanded, setAddressSelectExpanded] = useState(false);
-  const [selectedAddress, setSelectedAddress] = useState<string>('');
+  const [newDefaultAddress, setNewDefaultAddress] = useState<string>('');
   const { isMobile } = useWindowWidth();
 
   const toggleModal = () => {
     setAddressSelectExpanded((prev) => !prev);
-    setSelectedAddress('');
+    setNewDefaultAddress('');
   };
 
   const handleApply = () => {
-    setDefaultAccount(selectedAddress);
+    setDefaultAccount(newDefaultAddress);
+    setRememberSelectedAccount(shouldRemember);
     toggleModal();
+  };
+
+  const handleDropdownSelect = (option: string) => {
+    setNewDefaultAddress(option);
+    setShouldRemember(false);
+  };
+
+  const handleToggleRememberSelected = () => {
+    setShouldRemember((prev) => {
+      if (prev === true) {
+        setNewDefaultAddress('');
+      } else {
+        setNewDefaultAddress(selectedAccount);
+      }
+      return !prev;
+    });
   };
 
   return (
     <>
       <StyledValue onClick={toggleModal}>
-        {defaultAccount ? (
-          <>
-            {formatKey(defaultAccount, 8, 8)}
-            {!allAccounts.includes(defaultAccount) &&
-              !blockedWallets.includes(defaultAccount) && (
-                <StyledLabel>Not installed</StyledLabel>
-              )}
-            {blockedWallets.includes(defaultAccount) && (
-              <StyledLabel>Blocked</StyledLabel>
-            )}
-          </>
+        {rememberSelectedAccount ? (
+          'Remember Last Selected'
         ) : (
-          'None'
+          <>
+            {defaultAccount && (
+              <>
+                {formatKey(defaultAccount, 8, 8)}
+                {!allAccounts.includes(defaultAccount) &&
+                  !blockedWallets.includes(defaultAccount) && (
+                    <StyledLabel>Not installed</StyledLabel>
+                  )}
+                {blockedWallets.includes(defaultAccount) && (
+                  <StyledLabel>Blocked</StyledLabel>
+                )}
+              </>
+            )}
+            {!defaultAccount && 'None'}
+          </>
         )}
       </StyledValue>
       {addressSelectExpanded && (
@@ -51,11 +85,23 @@ export const DefaultAddress = () => {
           <Heading type="h4" marginBottom={48}>
             Default Wallet Address
           </Heading>
+          <StyledRememberSelected>
+            <Text bold>Remember the Last Selected as Default</Text>
+            <StyledSelect
+              $isSelected={shouldRemember}
+              onClick={handleToggleRememberSelected}
+            >
+              <Icon name="Check" size="16px" />
+            </StyledSelect>
+          </StyledRememberSelected>
+          <Text bold marginTop={10} marginBottom={10}>
+            or
+          </Text>
           <DropdownSelect
-            label="Wallet Address"
+            label="Select a Wallet Address"
             placeholder="Select Default Address"
             options={allAccounts}
-            onChange={(option) => setSelectedAddress(option)}
+            onChange={handleDropdownSelect}
             truncateOption
             truncateLength={14}
             error={undefined}
@@ -66,6 +112,8 @@ export const DefaultAddress = () => {
             onClick={() => {
               setDefaultAccount('');
               localStorage.removeItem('defaultAccount');
+              setRememberSelectedAccount(false);
+              setShouldRemember(false);
               toggleModal();
             }}
           >
@@ -80,7 +128,10 @@ export const DefaultAddress = () => {
             )}
             <Button
               variant="modalPrimary"
-              disabled={!selectedAddress || selectedAddress === defaultAccount}
+              disabled={
+                newDefaultAddress === defaultAccount &&
+                shouldRemember === rememberSelectedAccount
+              }
               onClick={handleApply}
             >
               Apply

--- a/src/layouts/Settings/components/DefaultAddress/styles.ts
+++ b/src/layouts/Settings/components/DefaultAddress/styles.ts
@@ -57,3 +57,30 @@ export const StyledActionButton = styled.button<{ $marginTop?: number }>`
     color: ${({ theme }) => theme.colors.textDisabled};
   }
 `;
+
+export const StyledRememberSelected = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  justify-content: space-between;
+  padding-right: 16px;
+`;
+
+export const StyledSelect = styled.div<{ $isSelected: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background-color: ${({ $isSelected }) =>
+    $isSelected ? '#FF2E72' : 'transparent'};
+  border: 2px solid
+    ${({ $isSelected, theme }) =>
+      $isSelected ? '#FF2E72' : theme.colors.textDisabled};
+  color: ${({ $isSelected }) => ($isSelected ? '#FFFFFF' : 'transparent')};
+  transition:
+    background-color 250ms ease-out,
+    color 250ms ease-out;
+  cursor: pointer;
+`;


### PR DESCRIPTION
This PR adds an optional setting to have the Portal remember the last key you have used instead of defaulting to the fist key returned by the connected wallet. 

This prevents wallets from changing when refreshing the page.