### PR TITLE
Migration logic for new GraphQL endpoints and rememberSelectedAccount as default setting

### DIFF
--- a/src/context/AccountContext/constants.ts
+++ b/src/context/AccountContext/constants.ts
@@ -51,6 +51,8 @@ export interface IAccountContext {
   multiSigAccount: MultiSig | null;
   selectedAccountBalance: IAccountBalance;
   balanceIsLoading: boolean;
+  rememberSelectedAccount: boolean;
+  setRememberSelectedAccount: (shouldRemember: boolean) => void;
 }
 
 export const initialState = {
@@ -78,4 +80,6 @@ export const initialState = {
   multiSigAccount: null,
   selectedAccountBalance: { free: '', locked: '', total: '' },
   balanceIsLoading: false,
+  rememberSelectedAccount: true,
+  setRememberSelectedAccount: () => {},
 };

--- a/src/context/AccountContext/provider.tsx
+++ b/src/context/AccountContext/provider.tsx
@@ -47,6 +47,11 @@ const AccountProvider = ({ children }: IProviderProps) => {
     'blockedWallets',
     [],
   );
+  const [rememberSelectedAccount, setRememberSelectedAccount] = useLocalStorage(
+    'rememberSelectedAccount',
+    true,
+  );
+
   const [identity, setIdentity] = useState<Identity | null>(null);
   const [allIdentities, setAllIdentities] = useState<(Identity | null)[]>([]);
   const [primaryKey, setPrimaryKey] = useState<string>('');
@@ -171,13 +176,10 @@ const AccountProvider = ({ children }: IProviderProps) => {
   }, [allAccounts, defaultAccount, selectedAccount]);
 
   useEffect(() => {
-    const rememberSelectedAccount = localStorage.getItem(
-      'rememberSelectedAccount',
-    );
-    if (rememberSelectedAccount === 'true' && selectedAccount) {
+    if (rememberSelectedAccount === true && selectedAccount) {
       setDefaultAccount(selectedAccount);
     }
-  }, [selectedAccount, setDefaultAccount]);
+  }, [rememberSelectedAccount, selectedAccount, setDefaultAccount]);
 
   // Set account instance when selected account changes
   useEffect(() => {
@@ -431,6 +433,8 @@ const AccountProvider = ({ children }: IProviderProps) => {
       multiSigAccount,
       selectedAccountBalance,
       balanceIsLoading,
+      rememberSelectedAccount,
+      setRememberSelectedAccount,
     }),
     [
       account,
@@ -451,10 +455,12 @@ const AccountProvider = ({ children }: IProviderProps) => {
       multiSigAccount,
       primaryKey,
       refreshAccountIdentity,
+      rememberSelectedAccount,
       secondaryKeys,
       selectedAccount,
       selectedAccountBalance,
       setDefaultAccount,
+      setRememberSelectedAccount,
       unblockWalletAddress,
     ],
   );

--- a/src/context/PolymeshContext/provider.tsx
+++ b/src/context/PolymeshContext/provider.tsx
@@ -130,6 +130,21 @@ const PolymeshProvider = ({ children }: IProviderProps) => {
         setInitialized(true);
       } catch (error) {
         notifyGlobalError((error as Error).message);
+        // this is a hacky work around for wallet errors due to chrome preloading
+        // the page and not passing the correct url from a new tab. Preloading may
+        // still cause authorization requests from incorrect pages requiring rejection
+        // and manual reload
+        if (
+          (error as Error).message ===
+            // error message from polywallet, polkadot.js
+            'Invalid url chrome://newtab/, expected to start with http: or https: or ipfs: or ipns:' ||
+          // error message from talisman extension
+          (error as Error).message.includes('URL protocol unsupported')
+        ) {
+          setTimeout(() => {
+            window.location.reload();
+          }, 1000);
+        }
       } finally {
         setConnecting(false);
       }

--- a/src/helpers/localStorageMigrations.ts
+++ b/src/helpers/localStorageMigrations.ts
@@ -1,0 +1,42 @@
+// function to compare semantic version strings
+const compareVersions = (a: string, b: string) => {
+  const partsA = a.split('.').map(Number);
+  const partsB = b.split('.').map(Number);
+
+  for (let i = 0; i < 3; i += 1) {
+    if (partsA[i] > partsB[i]) return 1;
+    if (partsA[i] < partsB[i]) return -1;
+  }
+
+  return 0;
+};
+
+interface ILocalStorageMigration {
+  middlewareUrl: string;
+  setMiddlewareUrl: React.Dispatch<React.SetStateAction<string>>;
+}
+
+// this function should be modified as required
+export const runMigration = (
+  localStorageMigrationParam: ILocalStorageMigration,
+) => {
+  const currentVersion = '1.0.0';
+
+  // Check if localStorage version exists
+  const storedVersion = localStorage.getItem('storageVersion');
+
+  if (!storedVersion || compareVersions(storedVersion, currentVersion) < 0) {
+    // Migration to new graphQl endpoints as default
+    const isOldDefault =
+      localStorageMigrationParam.middlewareUrl ===
+        'https://mainnet-graphqlnative.polymath.network/' ||
+      localStorageMigrationParam.middlewareUrl ===
+        'https://testnet-graphqlnative.polymath.network/';
+    if (isOldDefault) {
+      localStorageMigrationParam.setMiddlewareUrl(
+        import.meta.env.VITE_SUBQUERY_MIDDLEWARE_URL,
+      );
+    }
+    localStorage.setItem('storageVersion', currentVersion);
+  }
+};

--- a/src/layouts/Settings/components/DefaultAddress/index.tsx
+++ b/src/layouts/Settings/components/DefaultAddress/index.tsx
@@ -3,7 +3,7 @@ import { Icon, Modal } from '~/components';
 import { Heading, Button, DropdownSelect, Text } from '~/components/UiKit';
 import { AccountContext } from '~/context/AccountContext';
 import { formatKey } from '~/helpers/formatters';
-import { useLocalStorage, useWindowWidth } from '~/hooks/utility';
+import { useWindowWidth } from '~/hooks/utility';
 import {
   StyledValue,
   StyledButtonWrapper,
@@ -20,11 +20,9 @@ export const DefaultAddress = () => {
     setDefaultAccount,
     allAccounts,
     blockedWallets,
+    rememberSelectedAccount,
+    setRememberSelectedAccount,
   } = useContext(AccountContext);
-  const [rememberSelectedAccount, setRememberSelectedAccount] = useLocalStorage(
-    'rememberSelectedAccount',
-    false,
-  );
   const [shouldRemember, setShouldRemember] = useState(rememberSelectedAccount);
   const [addressSelectExpanded, setAddressSelectExpanded] = useState(false);
   const [newDefaultAddress, setNewDefaultAddress] = useState<string>('');


### PR DESCRIPTION
In this PR:
- adds migration logic to update users local storage stored graphQL endpoint to point to the new default one if the old default was set.
- set `rememberSelectedAccount` to `true` as the default behavior
- removes redundant account fetching for polywallet following update to 1.8.1
- handles errors if chrome preloads the page from  `chrome://newTab/`
