### PR TITLE
fix: add left alignment to label in `DidSelect` component

### DIFF
--- a/src/components/DidSelect/styles.ts
+++ b/src/components/DidSelect/styles.ts
@@ -66,6 +66,7 @@ export const StyledLabel = styled.label<{ $selected: boolean }>`
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+  text-align: left;
   padding: 12px 16px;
   border-radius: 62px;
   font-size: 14px;


### PR DESCRIPTION
#### Proposed changes:

- Before:
<img width="665" alt="Screenshot 2024-04-08 at 1 00 38 AM" src="https://github.com/PolymeshAssociation/polymesh-portal/assets/6185507/a75b653b-1be6-42ba-b4dc-cedb16a775df">

- After:
<img width="674" alt="Screenshot 2024-04-08 at 1 01 05 AM" src="https://github.com/PolymeshAssociation/polymesh-portal/assets/6185507/ab62bc0f-0d23-4df1-bd5f-c2c31596efa2">
