### PR TITLE
fix: correct icon state on menu open/close

### DIFF
--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -103,13 +103,7 @@ const Sidebar: React.FC<ISidebarProps> = ({
   const handleOpenLink = (url: string) => window.open(url, '_blank');
 
   useEffect(() => {
-    if (isMobile) return;
-
-    if (isTablet) {
-      setFullWidth(false);
-    } else {
-      setFullWidth(true);
-    }
+    if (!isMobile) setFullWidth(!isTablet);
   }, [isMobile, isTablet]);
 
   const sidebarExpanded = isMobile ? mobileMenuOpen : fullWidth;

--- a/src/components/Sidebar/styles.ts
+++ b/src/components/Sidebar/styles.ts
@@ -68,7 +68,7 @@ export const MenuButton = styled.button<{ $fullWidth: boolean }>`
   padding: 0;
   background-color: transparent;
   cursor: pointer;
-  ${({ $fullWidth }) => ($fullWidth ? 'transform: rotate(180deg);' : '')}
+  transform: ${({ $fullWidth }) => !$fullWidth && 'rotate(180deg)'};
   transition: transform 250ms ease-out;
 `;
 


### PR DESCRIPTION
#### Proposed changes:
The menu icon should show the intended action. In case the menu is open, "<=" is shown which tells users that the menu gets collapsed on onClick (see screenshot below).
<img width="290" alt="Screenshot 2024-04-08 at 1 48 12 AM" src="https://github.com/PolymeshAssociation/polymesh-portal/assets/6185507/ebab10fc-5052-4bf3-85ec-bc3b8f5fb0e3">
<img width="202" alt="Screenshot 2024-04-08 at 1 48 23 AM" src="https://github.com/PolymeshAssociation/polymesh-portal/assets/6185507/a5fec0c9-c516-44ac-9297-9a9ef1e27ab1">
