### PR TITLE
refactor: remove skeleton loader from <Table /> tabs

### DIFF
--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -152,17 +152,13 @@ const Table = <T, S>(props: ITableProps<T, S>) => {
   );
 
   const renderTabs = () => {
-    if (!tabs || tabs.length < 2) return null;
+    if (!tabs || tabs.length < 2 || !setTab) return null;
 
     if (isMobile) {
-      if (loading) return <SkeletonLoader height="36px" />;
-
       return (
         <DropdownSelect
           options={tabs}
-          onChange={(tabItem) =>
-            (setTab as Dispatch<SetStateAction<S>>)(tabItem as S)
-          }
+          onChange={(tabItem) => setTab(tabItem as S)}
           selected={tab}
           error={undefined}
           placeholder="Select tab"
@@ -173,21 +169,15 @@ const Table = <T, S>(props: ITableProps<T, S>) => {
 
     return (
       <StyledTabsWrapper>
-        {tabs.map((tabItem) =>
-          loading ? (
-            <SkeletonLoader key={tabItem} />
-          ) : (
-            <StyledTabItem
-              key={tabItem}
-              $selected={tabItem === tab}
-              onClick={() =>
-                (setTab as Dispatch<SetStateAction<S>>)(tabItem as S)
-              }
-            >
-              {tabItem}
-            </StyledTabItem>
-          ),
-        )}
+        {tabs.map((tabItem) => (
+          <StyledTabItem
+            key={tabItem}
+            $selected={tabItem === tab}
+            onClick={() => setTab(tabItem as S)}
+          >
+            {tabItem}
+          </StyledTabItem>
+        ))}
       </StyledTabsWrapper>
     );
   };


### PR DESCRIPTION
#### proposed changes:
The skeleton loader of tabs are removed because:

- They are static info
- The skeleton loader does not match the content size across all tabs, resulting in a UI that quickly becomes wider and shorter upon changing tabs.

 

https://github.com/PolymeshAssociation/polymesh-portal/assets/6185507/83802492-f3e4-4f12-b76e-03c906dc6038


