### PR TITLE
Add --max-old-space-size to build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host",
-    "build": "tsc && vite build",
+    "build": "tsc && export NODE_OPTIONS=\"--max-old-space-size=4096\" && vite build",
     "preview": "vite preview"
   },
   "dependencies": {


### PR DESCRIPTION
Prevents `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` during build