### PR TITLE
remove updated_at field for compatibility with SubQuery v15+

### DIFF
--- a/src/constants/queries/types.ts
+++ b/src/constants/queries/types.ts
@@ -121,7 +121,6 @@ export interface IDistribution {
   eventId: string;
   id: string;
   nodeId: string;
-  updatedAt: string;
   updatedBlockId: string;
 }
 

--- a/src/helpers/graphqlQueries.ts
+++ b/src/helpers/graphqlQueries.ts
@@ -235,7 +235,6 @@ export const historicalDistributionsQuery = ({
           eventId
           id
           nodeId
-          updatedAt
           updatedBlockId
         }
       }


### PR DESCRIPTION
Upstream SQ has removed the option for `created_at` and `updated_at`.  These were the only references to `updated_at` I could find.

I added `created_at` in our compat migration for backwards compatibility. With historical state enabled it should be the "updated at value" if no "as of" block is given, since its set per row.

https://github.com/PolymeshAssociation/polymesh-subquery/pull/241

