### PR TITLE
fix: filter out Ethereum key types

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*        @quinndiggitypolymath @F-OBrien @adamdossa
+*        @quinndiggitypolymath @F-OBrien @adamdossa @VictorVicente @mpastecki 

--- a/src/context/PolymeshContext/provider.tsx
+++ b/src/context/PolymeshContext/provider.tsx
@@ -147,6 +147,7 @@ const PolymeshProvider = ({ children }: IProviderProps) => {
           await BrowserExtensionSigningManager.create({
             appName: 'polymesh-portal',
             extensionName,
+            accountTypes: ['sr25519', 'ed25519', 'ecdsa'],
           });
         if (extensionName !== 'polywallet') {
           signingManagerInstance.setGenesisHash(


### PR DESCRIPTION
When attempting to SS58 encode keys returned from Nova Wallet an error. `Expected a valid key to convert with length 1,2,4,8,32,33` is returned. This is as Nova wallet recently started passing ethereum keys alongside typical substrate key pair types. This fix filters keys in the browser extension signing manager to exclude `ethereum` key pair types.