### PR TITLE
Add Toggleable Identity Providers Feature

### DIFF
--- a/src/components/UserAuth/components/PopupVerifyIdentity/components/BusinessProviderSelect/index.tsx
+++ b/src/components/UserAuth/components/PopupVerifyIdentity/components/BusinessProviderSelect/index.tsx
@@ -29,6 +29,10 @@ import {
   StyledTestnetList,
 } from './styles';
 
+const isProviderEnabled = (envVar: string | undefined): boolean => {
+  return envVar?.toLowerCase() === 'true';
+};
+
 export const BusinessProviderSelect = () => {
   const { windowWidth } = useWindowWidth();
 
@@ -38,6 +42,13 @@ export const BusinessProviderSelect = () => {
   const { setIdentityPopup } = useAuthContext();
 
   const [isTestnet, setIsTestnet] = useState<null | boolean>(null);
+
+  const providerEnabledMap: Record<string, boolean> = {
+    mockid: true,
+    finclusive_kyb: isProviderEnabled(
+      import.meta.env.VITE_PROVIDER_FINCLUSIVE_KYB_ENABLED ?? 'true',
+    ),
+  };
 
   const handleContactFormClick = () => {
     window.open('https://polymesh.network/contact-us', '_blank');
@@ -57,18 +68,22 @@ export const BusinessProviderSelect = () => {
   }, [sdk]);
 
   const renderFinclusiveKyb = () => {
+    const isDisabled = !providerEnabledMap.finclusive_kyb;
     return (
       <StyleProviderBox
         key={IDENTITY_PROVIDER_FINCLUSIVE_KYB.name}
-        onClick={() =>
-          setIdentityPopup({
-            type: FINCLUSIVE_BUSINESS_IDENTITY_PROVIDER,
-          })
-        }
+        onClick={() => {
+          if (!isDisabled) {
+            setIdentityPopup({
+              type: FINCLUSIVE_BUSINESS_IDENTITY_PROVIDER,
+            });
+          }
+        }}
       >
         <ProviderCard
           provider={IDENTITY_PROVIDER_FINCLUSIVE_KYB}
           isTestnet={isTestnet as boolean}
+          disabled={isDisabled}
         />
       </StyleProviderBox>
     );
@@ -128,19 +143,23 @@ export const BusinessProviderSelect = () => {
 
   const renderProviders = () => {
     if (isTestnet) {
+      const mockProviderDisabled = !providerEnabledMap.mockid;
       return (
         <StyledTestnetContainer>
           <StyleProviderBox
             key={MOCKID_IDENTITY_PROVIDER}
-            onClick={() =>
-              setIdentityPopup({
-                type: MOCKID_IDENTITY_PROVIDER,
-              })
-            }
+            onClick={() => {
+              if (!mockProviderDisabled) {
+                setIdentityPopup({
+                  type: MOCKID_IDENTITY_PROVIDER,
+                });
+              }
+            }}
           >
             <ProviderCard
               provider={IDENTITY_PROVIDER_MOCK}
               isTestnet={isTestnet as boolean}
+              disabled={mockProviderDisabled}
             />
           </StyleProviderBox>
           <StyledTestnetList>{renderFinclusiveKyb()}</StyledTestnetList>

--- a/src/components/UserAuth/components/PopupVerifyIdentity/components/ProviderCard/index.tsx
+++ b/src/components/UserAuth/components/PopupVerifyIdentity/components/ProviderCard/index.tsx
@@ -1,4 +1,3 @@
-import styled from 'styled-components';
 import { useWindowWidth } from '~/hooks/utility';
 import { Text, Heading } from '~/components/UiKit';
 import { Icon } from '~/components';
@@ -10,14 +9,8 @@ import {
   StyledProviderInfo,
   StyledProviderRegList,
   StyledTestnetLabel,
+  DisabledWrapper,
 } from './styles';
-
-// Create a wrapper to handle disabled state
-const DisabledWrapper = styled.div<{ $isDisabled: boolean }>`
-  position: relative;
-  opacity: ${({ $isDisabled }) => ($isDisabled ? 0.5 : 1)};
-  pointer-events: ${({ $isDisabled }) => ($isDisabled ? 'none' : 'auto')};
-`;
 
 interface IProviderCardProps {
   provider: IIdentityProvider;
@@ -32,16 +25,13 @@ export const ProviderCard: React.FC<IProviderCardProps> = ({
 }) => {
   const { windowWidth } = useWindowWidth();
 
-  // Apply the wrapper regardless of the rendering path
   return (
     <DisabledWrapper $isDisabled={disabled}>
       {isTestnet && provider.name.toLowerCase() !== MOCKID_IDENTITY_PROVIDER ? (
-        // Render the Testnet label INSIDE the wrapper
         <StyledTestnetLabel>
           <Heading type="h4">{provider.name} [Not for TESTNET]</Heading>
         </StyledTestnetLabel>
       ) : (
-        // Render the ActionCard INSIDE the wrapper (as before)
         <ActionCard
           hovered
           matomoData={{

--- a/src/components/UserAuth/components/PopupVerifyIdentity/components/ProviderCard/styles.ts
+++ b/src/components/UserAuth/components/PopupVerifyIdentity/components/ProviderCard/styles.ts
@@ -32,3 +32,9 @@ export const StyledTestnetLabel = styled.div`
   border-radius: 16px;
   cursor: pointer;
 `;
+
+export const DisabledWrapper = styled.div<{ $isDisabled: boolean }>`
+  position: relative;
+  opacity: ${({ $isDisabled }) => ($isDisabled ? 0.5 : 1)};
+  pointer-events: ${({ $isDisabled }) => ($isDisabled ? 'none' : 'auto')};
+`;

--- a/src/components/UserAuth/components/PopupVerifyIdentity/components/ProviderSelect/index.tsx
+++ b/src/components/UserAuth/components/PopupVerifyIdentity/components/ProviderSelect/index.tsx
@@ -21,7 +21,6 @@ import {
   StyledTestnetList,
 } from './styles';
 
-// Helper function to parse env var string to boolean
 const isProviderEnabled = (envVar: string | undefined): boolean => {
   return envVar?.toLowerCase() === 'true';
 };
@@ -47,7 +46,6 @@ export const ProviderSelect = () => {
     })();
   }, [sdk]);
 
-  // Read environment variables for provider availability
   const providerEnabledMap: Record<string, boolean> = {
     jumio: isProviderEnabled(
       import.meta.env.VITE_PROVIDER_JUMIO_ENABLED ?? 'true',
@@ -71,7 +69,6 @@ export const ProviderSelect = () => {
             key={MOCKID_IDENTITY_PROVIDER}
             onClick={() => {
               if (!mockProviderDisabled) {
-                // Check disabled state before setting popup
                 setIdentityPopup({
                   type: MOCKID_IDENTITY_PROVIDER,
                 });
@@ -98,7 +95,6 @@ export const ProviderSelect = () => {
                     key={providerDetails.name}
                     onClick={() => {
                       if (!isDisabled) {
-                        // Check disabled state before setting popup
                         setIdentityPopup({
                           type: provider as TIdentityModalType,
                         });
@@ -133,7 +129,6 @@ export const ProviderSelect = () => {
                 key={providerDetails.name}
                 onClick={() => {
                   if (!isDisabled) {
-                    // Check disabled state before setting popup
                     setIdentityPopup({
                       type: provider as TIdentityModalType,
                     });

--- a/src/components/UserAuth/components/PopupVerifyIdentity/components/ProviderSelect/index.tsx
+++ b/src/components/UserAuth/components/PopupVerifyIdentity/components/ProviderSelect/index.tsx
@@ -56,13 +56,12 @@ export const ProviderSelect = () => {
     finclusive: isProviderEnabled(
       import.meta.env.VITE_PROVIDER_FINCLUSIVE_ENABLED ?? 'true',
     ),
-    // Assuming MockID is always enabled for testnet
     mockid: true,
   };
 
   const renderProviders = () => {
     if (isTestnet) {
-      const mockProviderDisabled = !providerEnabledMap.mockid; // Use dot notation
+      const mockProviderDisabled = !providerEnabledMap.mockid;
       return (
         <StyledTestnetContainer>
           <StyleProviderBox
@@ -89,7 +88,7 @@ export const ProviderSelect = () => {
                   provider === FINCLUSIVE_BUSINESS_IDENTITY_PROVIDER
                 )
                   return null;
-                const isDisabled = !providerEnabledMap[provider.toLowerCase()]; // Determine disabled state
+                const isDisabled = !providerEnabledMap[provider.toLowerCase()];
                 return (
                   <StyleProviderBox
                     key={providerDetails.name}
@@ -123,7 +122,7 @@ export const ProviderSelect = () => {
               provider === FINCLUSIVE_BUSINESS_IDENTITY_PROVIDER
             )
               return null;
-            const isDisabled = !providerEnabledMap[provider.toLowerCase()]; // Determine disabled state
+            const isDisabled = !providerEnabledMap[provider.toLowerCase()];
             return (
               <StyleProviderBox
                 key={providerDetails.name}


### PR DESCRIPTION
This PR adds the ability to enable or disable identity providers through environment variables, giving administrators more control over which CDD providers are available to users.

## Changes

1. **Environment Variable Configuration**
   - Added support for controlling provider availability through env vars:
     - `VITE_PROVIDER_JUMIO_ENABLED`
     - `VITE_PROVIDER_NETKI_ENABLED`
     - `VITE_PROVIDER_FINCLUSIVE_ENABLED`
     - `VITE_PROVIDER_FINCLUSIVE_KYB_ENABLED` (for business verification)
   - Providers default to enabled if not explicitly set to `false`

2. **Provider Component Modifications**
   - Added a reusable `DisabledWrapper` component to style disabled providers
   - Moved the wrapper from inline definition to the styles file
   - Applied opacity reduction (50%) to visually indicate disabled state
   - Disabled pointer events to prevent interaction with disabled providers

3. **Provider Selection Logic**
   - Updated both individual and business provider selection components
   - Added conditional checks before provider selection to prevent navigation
   - Ensured providers are visually disabled in both regular and testnet views
   - Maintained backward compatibility with existing provider structure

## Notes
- All providers default to enabled to maintain current behavior
- Style and interaction changes are minimal and non-intrusive
