### PR TITLE
refactor: VITE_COOKIEBOT_ENABLED handling updated

### DIFF
--- a/src/components/CookieDeclarationModal/index.tsx
+++ b/src/components/CookieDeclarationModal/index.tsx
@@ -6,6 +6,14 @@ import { setCookiebotThemeProperties } from '~/utils/cookiebotTheme';
 import { Button, Heading, Text } from '../UiKit';
 import { StyledButtonsWrapper, StyledModalContent } from './styles';
 
+/**
+ * Check if Cookiebot is enabled from environment variable
+ * Handles both boolean and string values, similar to isProviderEnabled pattern
+ */
+const isCookiebotEnabled = (envVar: string | undefined): boolean => {
+  return envVar?.toLowerCase() === 'true';
+};
+
 interface ICookieDeclarationModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -22,8 +30,9 @@ const CookieDeclarationModal: React.FC<ICookieDeclarationModalProps> = ({
   const modalContentRef = useRef<HTMLDivElement>(null);
 
   const cookiebotId = import.meta.env.VITE_COOKIEBOT_ID;
-  const config = { enabled: import.meta.env.VITE_COOKIEBOT_ENABLED };
-  const cookiebotEnabled = config.enabled === 'true';
+  const cookiebotEnabled = isCookiebotEnabled(
+    import.meta.env.VITE_COOKIEBOT_ENABLED ?? 'false',
+  );
 
   useEffect(() => {
     // Set theme properties whenever theme changes

--- a/src/components/CookieDeclarationModal/index.tsx
+++ b/src/components/CookieDeclarationModal/index.tsx
@@ -22,7 +22,8 @@ const CookieDeclarationModal: React.FC<ICookieDeclarationModalProps> = ({
   const modalContentRef = useRef<HTMLDivElement>(null);
 
   const cookiebotId = import.meta.env.VITE_COOKIEBOT_ID;
-  const cookiebotEnabled = import.meta.env.VITE_COOKIEBOT_ENABLED === 'true';
+  const config = { enabled: import.meta.env.VITE_COOKIEBOT_ENABLED };
+  const cookiebotEnabled = config.enabled === 'true';
 
   useEffect(() => {
     // Set theme properties whenever theme changes

--- a/src/utils/cookiebot.ts
+++ b/src/utils/cookiebot.ts
@@ -2,13 +2,21 @@
  * Cookiebot utility functions for dynamic script loading
  */
 
+import { Themes } from '../context/ThemeContext/constants';
+import {
+  getSystemTheme,
+  isSystemThemeEnabled,
+} from '../context/ThemeContext/provider';
 import { theme as appTheme } from '../styles/theme';
 import { setCookiebotThemeProperties } from './cookiebotTheme';
-import {
-  isSystemThemeEnabled,
-  getSystemTheme,
-} from '../context/ThemeContext/provider';
-import { Themes } from '../context/ThemeContext/constants';
+
+/**
+ * Check if Cookiebot is enabled from environment variable
+ * Handles both boolean and string values, similar to isProviderEnabled pattern
+ */
+const isCookiebotEnabled = (envVar: string | undefined): boolean => {
+  return envVar?.toLowerCase() === 'true';
+};
 
 /**
  * Safely get item from localStorage with error handling
@@ -116,8 +124,9 @@ const watchThemeChanges = () => {
  */
 export const loadCookiebotScript = (): void => {
   const cookiebotId = import.meta.env.VITE_COOKIEBOT_ID;
-  const config = { enabled: import.meta.env.VITE_COOKIEBOT_ENABLED };
-  const cookiebotEnabled = config.enabled === 'true';
+  const cookiebotEnabled = isCookiebotEnabled(
+    import.meta.env.VITE_COOKIEBOT_ENABLED ?? 'false',
+  );
   const cookiebotGeoRegions = import.meta.env.VITE_COOKIEBOT_GEOREGIONS;
 
   // Skip loading if Cookiebot is disabled or ID is not set

--- a/src/utils/cookiebot.ts
+++ b/src/utils/cookiebot.ts
@@ -116,7 +116,8 @@ const watchThemeChanges = () => {
  */
 export const loadCookiebotScript = (): void => {
   const cookiebotId = import.meta.env.VITE_COOKIEBOT_ID;
-  const cookiebotEnabled = import.meta.env.VITE_COOKIEBOT_ENABLED === 'true';
+  const config = { enabled: import.meta.env.VITE_COOKIEBOT_ENABLED };
+  const cookiebotEnabled = config.enabled === 'true';
   const cookiebotGeoRegions = import.meta.env.VITE_COOKIEBOT_GEOREGIONS;
 
   // Skip loading if Cookiebot is disabled or ID is not set


### PR DESCRIPTION
- Modified VITE_COOKIEBOT_ENABLED handling: Changed from direct boolean comparison (=== 'true') to a helper function that handles string/undefined values
- Added isCookiebotEnabled helper: Consistent pattern for checking boolean environment variables that prevents Vite from optimizing them away
- Ensures runtime configurability: Environment variables can now be properly injected in Docker containers after build time