### PR TITLE
feat: complete Cookiebot theme integration and conditional rendering

### DIFF
--- a/src/components/CookieDeclarationModal/index.tsx
+++ b/src/components/CookieDeclarationModal/index.tsx
@@ -3,16 +3,9 @@ import { useTheme } from 'styled-components';
 import Modal from '~/components/Modal';
 import { useWindowWidth } from '~/hooks/utility';
 import { setCookiebotThemeProperties } from '~/utils/cookiebotTheme';
-import { Button, Heading, Text } from '../UiKit';
+import { isCookiebotEnabled } from '~/utils/cookiebot';
+import { Button, Heading } from '../UiKit';
 import { StyledButtonsWrapper, StyledModalContent } from './styles';
-
-/**
- * Check if Cookiebot is enabled from environment variable
- * Handles both boolean and string values, similar to isProviderEnabled pattern
- */
-const isCookiebotEnabled = (envVar: string | undefined): boolean => {
-  return envVar?.toLowerCase() === 'true';
-};
 
 interface ICookieDeclarationModalProps {
   isOpen: boolean;
@@ -176,34 +169,6 @@ const CookieDeclarationModal: React.FC<ICookieDeclarationModalProps> = ({
   }, [isDeclarationReady]);
 
   if (!isOpen || !isDeclarationReady) return null;
-
-  // Show message if Cookiebot is disabled
-  if (
-    !cookiebotEnabled ||
-    !cookiebotId ||
-    cookiebotId === 'VITE_COOKIEBOT_ID_NOT_SET' ||
-    !/^[a-zA-Z0-9-]+$/.test(cookiebotId)
-  ) {
-    return (
-      <Modal handleClose={onClose} customWidth="600px">
-        <StyledModalContent>
-          <Heading type="h2" marginBottom={12}>
-            Cookie Declaration
-          </Heading>
-          <Text>
-            Cookie declaration is currently disabled or not configured.
-          </Text>
-        </StyledModalContent>
-        {!isMobile && (
-          <StyledButtonsWrapper>
-            <Button variant="modalSecondary" marginTop={40} onClick={onClose}>
-              Close
-            </Button>
-          </StyledButtonsWrapper>
-        )}
-      </Modal>
-    );
-  }
 
   return (
     <Modal

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Text } from '~/components/UiKit';
 import { CookieDeclarationModal } from '~/components';
+import { isCookiebotEnabled } from '~/utils/cookiebot';
 import {
   StyledContainer,
   StyledFooter,
@@ -14,6 +15,10 @@ interface IFooterProps {
 
 const Footer: React.FC<IFooterProps> = ({ isLandingPage }) => {
   const [isCookieModalOpen, setIsCookieModalOpen] = useState(false);
+
+  const cookiebotEnabled = isCookiebotEnabled(
+    import.meta.env.VITE_COOKIEBOT_ENABLED ?? 'false',
+  );
 
   const handleOpenCookieModal = () => {
     setIsCookieModalOpen(true);
@@ -49,19 +54,23 @@ const Footer: React.FC<IFooterProps> = ({ isLandingPage }) => {
                 Privacy Policy
               </StyledFooterLink>
             </li>
-            <li>
-              <StyledFooterLink as="button" onClick={handleOpenCookieModal}>
-                Cookie Declaration
-              </StyledFooterLink>
-            </li>
+            {cookiebotEnabled && (
+              <li>
+                <StyledFooterLink as="button" onClick={handleOpenCookieModal}>
+                  Cookie Declaration
+                </StyledFooterLink>
+              </li>
+            )}
           </StyledLinkList>
         </StyledContainer>
       </StyledFooter>
 
-      <CookieDeclarationModal
-        isOpen={isCookieModalOpen}
-        onClose={handleCloseCookieModal}
-      />
+      {cookiebotEnabled && (
+        <CookieDeclarationModal
+          isOpen={isCookieModalOpen}
+          onClose={handleCloseCookieModal}
+        />
+      )}
     </>
   );
 };

--- a/src/utils/cookiebot.ts
+++ b/src/utils/cookiebot.ts
@@ -14,7 +14,7 @@ import { setCookiebotThemeProperties } from './cookiebotTheme';
  * Check if Cookiebot is enabled from environment variable
  * Handles both boolean and string values, similar to isProviderEnabled pattern
  */
-const isCookiebotEnabled = (envVar: string | undefined): boolean => {
+export const isCookiebotEnabled = (envVar: string | undefined): boolean => {
   return envVar?.toLowerCase() === 'true';
 };
 

--- a/src/utils/cookiebotTheme.ts
+++ b/src/utils/cookiebotTheme.ts
@@ -49,7 +49,51 @@ const applyCookiebotButtonStyles = (): void => {
       color: var(--cookiebot-button3-text) !important;
       border: 2px solid var(--cookiebot-button3-border) !important;
     }
-    
+
+    /* Specific selector for the OK/Accept button */
+    #CybotCookiebotDialog #CybotCookiebotDialogBodyButtonAccept {
+      background-color: var(--cookiebot-button1-bg) !important;
+      color: var(--cookiebot-button1-text) !important;
+      border: 2px solid var(--cookiebot-button1-border) !important;
+    }
+
+    /* Active tab navigation styling */
+    #CybotCookiebotDialog .CybotCookiebotDialogActive,
+    #CybotCookiebotDialog #CybotCookiebotDialogNavDetails.CybotCookiebotDialogActive {
+      border-bottom-color: var(--cookiebot-button1-bg) !important;
+    }
+
+    /* Tab navigation pseudo-elements for active state */
+    #CybotCookiebotDialog .CybotCookiebotDialogActive::after,
+    #CybotCookiebotDialog #CybotCookiebotDialogNavDetails.CybotCookiebotDialogActive::after {
+      border-bottom-color: var(--cookiebot-button1-bg) !important;
+      background-color: var(--cookiebot-button1-bg) !important;
+    }
+
+    /* Toggle switches (checkboxes) when checked */
+    #CybotCookiebotDialog input[type="checkbox"]:checked + .CybotCookiebotDialogBodyLevelButtonSlider {
+      background-color: var(--cookiebot-button1-bg) !important;
+    }
+
+    /* Toggle switch knobs */
+    #CybotCookiebotDialog input[type="checkbox"]:checked + .CybotCookiebotDialogBodyLevelButtonSlider::before {
+      background-color: var(--cookiebot-button1-text) !important;
+    }
+
+    /* All links in the dialog */
+    #CybotCookiebotDialog a,
+    #CybotCookiebotDialog #CybotCookiebotDialogPoweredbyLink,
+    #CybotCookiebotDialog .CybotCookiebotDialogDetailBodyContentCookieLink {
+      color: var(--cookiebot-button1-bg) !important;
+    }
+
+    /* Link hover states */
+    #CybotCookiebotDialog a:hover,
+    #CybotCookiebotDialog #CybotCookiebotDialogPoweredbyLink:hover,
+    #CybotCookiebotDialog .CybotCookiebotDialogDetailBodyContentCookieLink:hover {
+      color: var(--cookiebot-button1-border) !important;
+    }
+
     /* Fix scrollbar containers in dark theme */
     #CybotCookiebotDialog .CybotCookiebotScrollbarContainer {
       background-color: var(--cookiebot-scrollbar-bg) !important;


### PR DESCRIPTION
- Handle VITE_COOKIEBOT_ENABLED at runtime with proper helper function
- Conditionally show/hide Cookie Declaration link in footer
- Fix all blue accent colors (tabs, toggles, links) to use Polymesh theme colors
- Add comprehensive CSS selectors for buttons and interactive elements
- Remove obsolete disabled state handling