### PR TITLE
fix: bump polymesh-action-public to v2.0.2 to support new GitHub token format

### DIFF
--- a/.github/workflows/auth-ff-merge.yml
+++ b/.github/workflows/auth-ff-merge.yml
@@ -19,7 +19,7 @@ jobs:
       issues: write
     steps:
       - name: Polymesh Action - Auth and Fast-Forward
-        uses: PolymeshAssociation/polymesh-action-public@v2.0.1
+        uses: PolymeshAssociation/polymesh-action-public@v2.0.2
         with:
           allowed-signers: ${{ vars.MIDDLEWARE_ALLOWED_SIGNERS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
GitHub rolled out stateless JWT-based installation tokens (`ghs_`) in May 2026. The new tokens are ~520 characters long and contain dots and underscores as JWT separators, which caused `polymesh-action-public@v2.0.1` to reject valid GITHUB_TOKEN values with "Invalid GitHub token format".
The fix was applied in the action itself ([polymesh-action-public v2.0.2](https://github.com/PolymeshAssociation/polymesh-action-public/releases/tag/v2.0.2)). This PR bumps the workflow to use the patched version.